### PR TITLE
feat: Bump dappNode docker image

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -29,14 +29,13 @@ jobs:
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#binary-hoprd-aarch64-linux
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@a178becb8c3711ae955bad477861bfefe6feceae # build-binaries-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
       contents: read
     with:
       source_branch: ${{ github.event.pull_request.merge_commit_sha }}
       version_type: pr
       architecture: ${{ matrix.architecture }}
-      cachix_cache_name: hoprnet
       build_file: ./hoprd/Cargo.toml
       build_command: ${{ matrix.build_command }}
       binary: hoprd
@@ -49,7 +48,7 @@ jobs:
     name: Docker
     needs: build-binaries
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@43b03a7b5df777770d95c6524f48be34184b26fa # build-docker-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
     permissions:
       contents: read
       pull-requests: write
@@ -70,7 +69,6 @@ jobs:
             "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }
         ]
-      cachix_cache_name: hoprnet
       build_file: ./hoprd/Cargo.toml
       docker_image_name: hoprd
       docker_image_format: skopeo
@@ -91,7 +89,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Restart Hoprd
+      - name: Deploy to Gnosis Dev
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.GNOSIS_GITHUB_WORKFLOW_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -124,14 +124,13 @@ jobs:
             runner: depot-macos-15
             build_command: nix build -L .#binary-hoprd-x86_64-darwin
             required_label: binary:x86_64-darwin
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@a178becb8c3711ae955bad477861bfefe6feceae # build-binaries-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
       contents: read
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       version_type: commit
       architecture: ${{ matrix.architecture }}
-      cachix_cache_name: hoprnet
       build_file: ./hoprd/Cargo.toml
       build_command: ${{ matrix.build_command }}
       binary: hoprd
@@ -144,7 +143,7 @@ jobs:
   build-docker:
     name: Docker
     needs: build-binaries
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@43b03a7b5df777770d95c6524f48be34184b26fa # build-docker-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
     permissions:
       contents: read
       pull-requests: write
@@ -162,7 +161,6 @@ jobs:
             "build_debug_command": "nix build -L .#docker-hoprd-dev-x86_64-linux"
           }
         ]
-      cachix_cache_name: hoprnet
       build_file: ./hoprd/Cargo.toml
       docker_image_name: hoprd
       docker_image_format: skopeo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,7 +110,6 @@ jobs:
     needs: release
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Bump dappnode testnet package
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,14 +31,13 @@ jobs:
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#binary-hoprd-aarch64-linux
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@a178becb8c3711ae955bad477861bfefe6feceae # build-binaries-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
       contents: read
     with:
       source_branch: ${{ github.ref_name }}
       version_type: release
       architecture: ${{ matrix.architecture }}
-      cachix_cache_name: hoprnet
       build_file: ./hoprd/Cargo.toml
       build_command: ${{ matrix.build_command }}
       binary: hoprd
@@ -49,7 +48,7 @@ jobs:
       gpg_private_key: ${{ secrets.GPG_HOPRNET_PRIVATE_KEY }}
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@43b03a7b5df777770d95c6524f48be34184b26fa # build-docker-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
     needs: build-binaries
     permissions:
       contents: read
@@ -63,8 +62,7 @@ jobs:
           {
             "runner": "depot-ubuntu-24.04-4",
             "architecture": "x86_64-linux",
-            "build_command": "nix build -L .#docker-hoprd-x86_64-linux",
-            "smoke_test_command": "nix develop -c just smoke-test"
+            "build_command": "nix build -L .#docker-hoprd-x86_64-linux"
           },
           {
             "runner": "depot-ubuntu-24.04-4",
@@ -72,7 +70,6 @@ jobs:
             "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }
         ]
-      cachix_cache_name: hoprnet
       build_file: ./hoprd/Cargo.toml
       docker_image_name: hoprd
       docker_image_format: skopeo
@@ -89,31 +86,43 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
+    outputs:
+      released_version: ${{ steps.release_version.outputs.current_version }}
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@4e3c270b51ed1817bc0b0f6996dfc8a7b0e757c1 # release-version-v2
+        id: release_version
+        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v4
         with:
           source_branch: ${{ github.ref_name }}
           file: ./hoprd/Cargo.toml
           release_type: ${{ inputs.release_type }}
-          package_name: hoprd
-          cachix_cache_name: hoprnet
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_channel: HOPRd
           zulip_topic: Releases
           gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+          gcp_artifact_package: hoprd
           github_token: ${{ secrets.GH_RUNNER_TOKEN }}
-  deploy-staging:
-    name: Deploy Gnosis Staging
+  post-release:
+    name: Post Release
     runs-on: depot-ubuntu-24.04
-    needs: [build-docker, release]
+    needs: release
     permissions:
       contents: read
       id-token: write
     steps:
-      - name: Restart Hoprd
+      - name: Bump dappnode testnet package
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.GNOSIS_GITHUB_WORKFLOW_TOKEN }}
+          repository: dappnode/DAppNodePackage-Hopr-testnet
+          event-type: bump
+          client-payload: |-
+            {
+              "hoprd_version": "${{ needs.release.outputs.released_version }}"
+            }
+      - name: Deploy to Gnosis Staging
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.GNOSIS_GITHUB_WORKFLOW_TOKEN }}


### PR DESCRIPTION
- Changes cachix cache
- Bump workflows to tagged versions
- Remove buggy smoke test
- Bump the `dappnode/DAppNodePackage-Hopr-testnet` repository `hoprd` docker image