### PR TITLE
fix(localcluster): respect parent env for OTel config vars

### DIFF
--- a/localcluster/src/main.rs
+++ b/localcluster/src/main.rs
@@ -208,10 +208,24 @@ async fn start_hoprd_nodes(
             .arg(format!("{}:{}", &args.p2p_host, p2p_port))
             .arg("--password")
             .arg(&args.identity_password)
-            .env("HOPRD_USE_OPENTELEMETRY", "true")
-            .env("HOPRD_OTEL_SIGNALS", "metrics")
-            .env("HOPRD_OTLP_ENDPOINT", "http://localhost:4318")
-            .env("HOPRD_METRIC_EXPORT_INTERVAL", "15000,hopr_session=1000")
+            .env(
+                "HOPRD_USE_OPENTELEMETRY",
+                std::env::var("HOPRD_USE_OPENTELEMETRY").unwrap_or_else(|_| "true".to_string()),
+            )
+            .env(
+                "HOPRD_OTEL_SIGNALS",
+                std::env::var("HOPRD_OTEL_SIGNALS").unwrap_or_else(|_| "metrics".to_string()),
+            )
+            .env(
+                "HOPRD_OTLP_ENDPOINT",
+                std::env::var("HOPRD_OTLP_ENDPOINT")
+                    .unwrap_or_else(|_| "http://localhost:4318".to_string()),
+            )
+            .env(
+                "HOPRD_METRIC_EXPORT_INTERVAL",
+                std::env::var("HOPRD_METRIC_EXPORT_INTERVAL")
+                    .unwrap_or_else(|_| "15000,hopr_session=1000".to_string()),
+            )
             .env(
                 "HOPR_TX_TIMEOUT_MULTIPLIER",
                 DEFAULT_TX_TIMEOUT_MULTIPLIER.to_string(),


### PR DESCRIPTION
## Summary

- The four `HOPRD_*` OTel env vars (`HOPRD_USE_OPENTELEMETRY`, `HOPRD_OTEL_SIGNALS`, `HOPRD_OTLP_ENDPOINT`, `HOPRD_METRIC_EXPORT_INTERVAL`) were hard-coded when spawning child `hoprd` processes, making parent-level overrides impossible.
- Each variable now falls back to its hard-coded default only when not present in the parent environment.
- Callers can now suppress OTel export (e.g. in test environments with no OTLP collector) by setting `HOPRD_USE_OPENTELEMETRY=false` before launching `hoprd-localcluster`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry settings can now be configured through environment variables, with sensible defaults applied when not specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoprnet/hoprd/pull/21)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->