### PR TITLE
chore: Always pull chain img for localcluster

### DIFF
--- a/localcluster/src/blokli_helper.rs
+++ b/localcluster/src/blokli_helper.rs
@@ -57,6 +57,8 @@ impl ChainHandle {
         let mut cmd = Command::new(runtime);
         cmd.arg("run")
             .arg("--rm")
+            .arg("--pull")
+            .arg("always")
             .arg("--name")
             .arg(name)
             .arg("--platform")


### PR DESCRIPTION
Adding always pull for CHAIN_IMAGE for the localcluster, so it doesn't use obsolete versions