### PR TITLE
chore: change runners + address audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,11 +5,8 @@ ignore = [
   "RUSTSEC-2025-0073", # 'alloy-dyn-abi' in 'alloy' - will be removed in 4.0
   "RUSTSEC-2025-0137", # `alloy` - held back until removed, see https://github.com/hoprnet/hoprnet/issues/7707
   "RUSTSEC-2026-0049", # `rustls-webpki` - needs alloy removal
-  "RUSTSEC-2026-0097", # workspace already pins `rand` 0.10.1, but Cargo.lock still contains transitive `rand` 0.9.3; remove this ignore once upstream deps stop pulling 0.9.3
-  "RUSTSEC-2026-0098", # `rustls-webpki` 0.101.7 pulled transitively by blokli-client -> eventsource-client 0.16.2 -> hyper-rustls 0.24.2; our own `rustls-webpki` bumped to >=0.103.12 in Cargo.lock. Drop once blokli-client upgrades eventsource-client (see https://github.com/hoprnet/blokli/issues/107)
   "RUSTSEC-2026-0118", # `hickory-proto` 0.25.2 pulled by libp2p-dns 0.44.0 -> libp2p 0.56.0; no fix for 0.25.x; cannot remove without a major libp2p bump
-  "RUSTSEC-2026-0119", # same root cause as 0118 (different advisory DB version); hickory-proto 0.26.x is fixed via hickory-proto 0.26.1
-  "RUSTSEC-2026-0120", # `hickory-net` 0.26.0 pulled by hopr-network-types via hickory-resolver. Fix exists at 0.26.1 but requires coordinated bump of pinned hoprnet rev (HEAD has incompatible hopr-api API changes). Drop once hoprnet rev is bumped.
+  "RUSTSEC-2026-0119", # same root cause as 0118 (different advisory DB version); hickory-proto 0.25.2 still pulled by libp2p 0.56.0; remove together with 0118 once libp2p is bumped past 0.56.0
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -29,7 +29,7 @@ jobs:
             build_file: ./hoprd/Cargo.toml
             binary: hoprd
           - architecture: aarch64-linux
-            runner: depot-ubuntu-24.04-8
+            runner: depot-ubuntu-24.04-arm-8
             build_command: nix build -L .#binary-hoprd-aarch64-linux
             build_file: ./hoprd/Cargo.toml
             binary: hoprd
@@ -73,7 +73,7 @@ jobs:
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-24.04-4",
+            "runner": "depot-ubuntu-24.04-arm-4",
             "architecture": "aarch64-linux",
             "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -115,7 +115,7 @@ jobs:
             binary: hoprd
             required_label: ""
           - architecture: aarch64-linux
-            runner: depot-ubuntu-24.04-8
+            runner: depot-ubuntu-24.04-arm-8
             build_command: nix build -L .#binary-hoprd-aarch64-linux
             build_file: ./hoprd/Cargo.toml
             binary: hoprd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
             runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#binary-hoprd-x86_64-linux
           - architecture: aarch64-linux
-            runner: depot-ubuntu-24.04-8
+            runner: depot-ubuntu-24.04-arm-8
             build_command: nix build -L .#binary-hoprd-aarch64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
@@ -65,7 +65,7 @@ jobs:
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-24.04-4",
+            "runner": "depot-ubuntu-24.04-arm-4",
             "architecture": "aarch64-linux",
             "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }


### PR DESCRIPTION
In this PR:
- use ARM runners for building ARM version of binary #8 
- address cargo audit #7