### PR TITLE
chore: cleanup Cargo.toml files

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -73,7 +73,7 @@ jobs:
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-24.04-arm-4",
+            "runner": "depot-ubuntu-24.04-4",
             "architecture": "aarch64-linux",
             "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ members = ["hoprd", "rest-api", "rest-api-client", "localcluster"]
 rust-version = "1.91"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
+license = "GPL-3.0-only"
+homepage = "https://hoprnet.org/"
+repository = "https://github.com/hoprnet/hoprd"
 
 [workspace.dependencies]
 hoprd = { path = "hoprd", default-features = false }
@@ -26,6 +29,7 @@ hopr-api = { version = "=1.9.0" }
 
 # Third-party deps
 anyhow = "1.0.102"
+home = "0.5.12"
 async-signal = "0.2.14"
 async-trait = "0.1.89"
 axum = { version = "0.8.9", features = ["http2"] }

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -5,9 +5,9 @@ authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "A complete HOPR node daemon and reference implementation of the HOPR protocol"
-homepage = "https://hoprnet.org/"
-repository = "https://github.com/hoprnet/hoprd"
-license = "GPL-3.0-only"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 build = "build.rs"
 
 [features]
@@ -76,7 +76,7 @@ lazy_static = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
 futures = { workspace = true }
 flagset = { workspace = true, optional = true }
-home = "0.5.12"
+home = { workspace = true }
 humansize = { workspace = true, optional = true, features = ["no_alloc"] }
 humantime-serde = { workspace = true }
 proc-macro-regex = { workspace = true }

--- a/localcluster/Cargo.toml
+++ b/localcluster/Cargo.toml
@@ -12,7 +12,7 @@ description = "Local HOPR cluster runner using external hoprd processes"
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 hoprd = { workspace = true, features = [
   "runtime-tokio",
@@ -33,7 +33,7 @@ hopr-reference = { workspace = true, features = [
 hoprd-api-client = { workspace = true }
 hoprd-api = { workspace = true }
 lazy_static = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 serde-saphyr = { workspace = true }
 tokio = { workspace = true, features = [
   "macros",

--- a/localcluster/Cargo.toml
+++ b/localcluster/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "hoprd-localcluster"
 version = "0.2.0"
-authors = ["HOPR Association <tech@hoprnet.org>"]
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "GPL-3.0-only"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 description = "Local HOPR cluster runner using external hoprd processes"
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true }
 futures = { workspace = true }
 hoprd = { workspace = true, features = [
   "runtime-tokio",
@@ -31,7 +33,7 @@ hopr-reference = { workspace = true, features = [
 hoprd-api-client = { workspace = true }
 hoprd-api = { workspace = true }
 lazy_static = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true }
 serde-saphyr = { workspace = true }
 tokio = { workspace = true, features = [
   "macros",

--- a/rest-api-client/Cargo.toml
+++ b/rest-api-client/Cargo.toml
@@ -17,8 +17,8 @@ http = { workspace = true }
 percent-encoding = { workspace = true }
 serde_urlencoded = { workspace = true }
 progenitor-client = { workspace = true }
-reqwest = { workspace = true }
-serde = { workspace = true }
+reqwest = { workspace = true, features = ["json", "stream"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 chrono = { workspace = true, features = ["serde", "clock"] }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/rest-api-client/Cargo.toml
+++ b/rest-api-client/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "hoprd-api-client"
 version = "0.1.2"
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "GPL-3.0-only"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 description = "Generated Rust client for hoprd REST API"
 
 [dependencies]
@@ -14,8 +17,8 @@ http = { workspace = true }
 percent-encoding = { workspace = true }
 serde_urlencoded = { workspace = true }
 progenitor-client = { workspace = true }
-reqwest = { workspace = true, features = ["json", "stream"] }
-serde = { workspace = true, features = ["derive"] }
+reqwest = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true, features = ["serde", "clock"] }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/rest-api/Cargo.toml
+++ b/rest-api/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "hoprd-api"
 version = "4.11.0"
-authors = ["HOPR Association <tech@hoprnet.org>"]
+authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "API enabling developers to interact with a hoprd node programatically through HTTP REST API."
-homepage = "https://hoprnet.org/"
-repository = "https://github.com/hoprnet/hoprd"
-license = "GPL-3.0-only"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["rlib"]
@@ -18,7 +18,7 @@ telemetry = ["hopr-lib/telemetry", "dep:lazy_static", "dep:regex"]
 runtime-tokio = ["hopr-lib/runtime-tokio"]
 
 [dependencies]
-axum = { workspace = true, features = ["http2"] }
+axum = { workspace = true }
 human-bandwidth = { workspace = true }
 base64 = { workspace = true }
 bytesize = { workspace = true }

--- a/rest-api/Cargo.toml
+++ b/rest-api/Cargo.toml
@@ -18,7 +18,7 @@ telemetry = ["hopr-lib/telemetry", "dep:lazy_static", "dep:regex"]
 runtime-tokio = ["hopr-lib/runtime-tokio"]
 
 [dependencies]
-axum = { workspace = true }
+axum = { workspace = true, features = ["http2"] }
 human-bandwidth = { workspace = true }
 base64 = { workspace = true }
 bytesize = { workspace = true }


### PR DESCRIPTION
Cleanup of Cargo.toml files. Moving what can be moved to workspace.
Additionally fixed bug https://github.com/hoprnet/hoprd/actions/runs/26034119831/job/76533091908 from recent change. Aarch64 docker build still requires x86 machine 