### PR TITLE
feat(localcluster): more options to open channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-localcluster"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/docs/localcluster/README.md
+++ b/docs/localcluster/README.md
@@ -152,6 +152,17 @@ Flags take precedence over env vars. Only the flags marked with an env var below
 | `--channel-management` | —                         | `api`             | Channel management mode: `api` (manual REST open), `strategy` (channel strategy only), `both`, or `none`                  |
 | `--extra-identities`   | —                         | `0`               | Extra pre-funded identities for external tooling (0–5)                                                                    |
 
+### Channel management modes
+
+`--channel-management` controls how payment channels are opened during cluster startup:
+
+- `api` (default): Localcluster opens channels explicitly via REST API calls (`POST /api/v4/channels`) and waits for full-mesh channels to become open.
+- `strategy`: Localcluster enables the node channel strategy in generated `hoprd` configs, does not make manual REST `open_channel` calls, and waits for full-mesh channels to become open.
+- `both`: Localcluster enables strategy and also performs manual REST channel opening, then waits for full-mesh channels.
+- `none`: Localcluster disables both strategy-driven and manual startup channel opening, and skips channel topology waiting.
+
+Use `api` for deterministic startup behavior, `strategy` for strategy-only testing, `both` for mixed behavior checks, and `none` when you want to manage channels manually after startup.
+
 ---
 
 ## Cluster data layout

--- a/docs/localcluster/README.md
+++ b/docs/localcluster/README.md
@@ -134,23 +134,23 @@ All three should print `200`. The endpoints (defined in `rest-api/src/checks.rs`
 
 Flags take precedence over env vars. Only the flags marked with an env var below support one.
 
-| Flag                  | Env var                   | Default           | Description                                                                                                               |
-| --------------------- | ------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `--size`              | —                         | `3`               | Number of nodes to start (1–5)                                                                                            |
-| `--api-host`          | —                         | `localhost`       | Host to bind the REST API on                                                                                              |
-| `--api-port-base`     | —                         | `3000`            | First API port (each node gets base + id)                                                                                 |
-| `--p2p-host`          | —                         | `127.0.0.1`       | Host to bind P2P on (use an IP address for local clusters; hostname-based multiaddrs require DNS resolution at dial time) |
-| `--p2p-port-base`     | —                         | `9000`            | First P2P port                                                                                                            |
-| `--data-dir`          | —                         | `/tmp/hopr-nodes` | Root for configs, identities, DBs, logs                                                                                   |
-| `--chain-image`       | `HOPRD_CHAIN_IMAGE`       | —                 | Container image for Blokli + Anvil                                                                                        |
-| `--chain-url`         | `HOPRD_CHAIN_URL`         | —                 | External Blokli URL; skips the container step                                                                             |
-| `--container-runtime` | `HOPRD_CONTAINER_RUNTIME` | `docker`          | Container CLI (`docker`, `container`, `podman`, …)                                                                        |
-| `--hoprd-bin`         | —                         | `hoprd`           | Path to the `hoprd` binary                                                                                                |
-| `--identity-password` | —                         | `password`        | Password for identity encryption                                                                                          |
-| `--api-token`         | —                         | none              | Bearer token for the REST API                                                                                             |
-| `--funding-amount`    | —                         | `1 wxHOPR`        | Per-channel funding amount                                                                                                |
-| `--skip-channels`     | —                         | `false`           | Skip opening payment channels                                                                                             |
-| `--extra-identities`  | —                         | `0`               | Extra pre-funded identities for external tooling (0–5)                                                                    |
+| Flag                   | Env var                   | Default           | Description                                                                                                               |
+| ---------------------- | ------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `--size`               | —                         | `3`               | Number of nodes to start (1–5)                                                                                            |
+| `--api-host`           | —                         | `localhost`       | Host to bind the REST API on                                                                                              |
+| `--api-port-base`      | —                         | `3000`            | First API port (each node gets base + id)                                                                                 |
+| `--p2p-host`           | —                         | `127.0.0.1`       | Host to bind P2P on (use an IP address for local clusters; hostname-based multiaddrs require DNS resolution at dial time) |
+| `--p2p-port-base`      | —                         | `9000`            | First P2P port                                                                                                            |
+| `--data-dir`           | —                         | `/tmp/hopr-nodes` | Root for configs, identities, DBs, logs                                                                                   |
+| `--chain-image`        | `HOPRD_CHAIN_IMAGE`       | —                 | Container image for Blokli + Anvil                                                                                        |
+| `--chain-url`          | `HOPRD_CHAIN_URL`         | —                 | External Blokli URL; skips the container step                                                                             |
+| `--container-runtime`  | `HOPRD_CONTAINER_RUNTIME` | `docker`          | Container CLI (`docker`, `container`, `podman`, …)                                                                        |
+| `--hoprd-bin`          | —                         | `hoprd`           | Path to the `hoprd` binary                                                                                                |
+| `--identity-password`  | —                         | `password`        | Password for identity encryption                                                                                          |
+| `--api-token`          | —                         | none              | Bearer token for the REST API                                                                                             |
+| `--funding-amount`     | —                         | `1 wxHOPR`        | Per-channel funding amount                                                                                                |
+| `--channel-management` | —                         | `api`             | Channel management mode: `api` (manual REST open), `strategy` (channel strategy only), `both`, or `none`                  |
+| `--extra-identities`   | —                         | `0`               | Extra pre-funded identities for external tooling (0–5)                                                                    |
 
 ---
 

--- a/localcluster/Cargo.toml
+++ b/localcluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-localcluster"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/localcluster/src/cli.rs
+++ b/localcluster/src/cli.rs
@@ -81,6 +81,10 @@ pub struct Args {
     #[arg(long)]
     pub api_token: Option<String>,
 
+    /// Per-channel funding amount used for REST API channel opening
+    #[arg(long, default_value = "1 wxHOPR", value_parser = parse_funding_amount)]
+    pub funding_amount: String,
+
     /// Number of pre-funded extra identities to create alongside the cluster (0–5).
     /// Each gets its own Safe + Module, is written to `--data-dir` as an encrypted
     /// keystore (`extra_id_{i}.id`, password "local-cluster"), and is NOT run as a
@@ -107,4 +111,12 @@ fn parse_extras(s: &str) -> Result<usize, String> {
         ));
     }
     Ok(n)
+}
+
+fn parse_funding_amount(s: &str) -> Result<String, String> {
+    let value = s.trim();
+    if value.is_empty() {
+        return Err("funding-amount must not be empty".to_string());
+    }
+    Ok(value.to_string())
 }

--- a/localcluster/src/cli.rs
+++ b/localcluster/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 use crate::identity::{
     DEFAULT_CONFIG_HOME, DEFAULT_IDENTITY_PASSWORD, DEFAULT_NUM_EXTRA_IDENTITIES,
@@ -29,9 +29,9 @@ pub struct Args {
     #[arg(long, default_value_t = DEFAULT_NUM_NODES, value_parser = parse_size)]
     pub size: usize,
 
-    /// Skip waiting for the channel-lifecycle strategy to open the full mesh
-    #[arg(long, default_value_t = false)]
-    pub skip_channels: bool,
+    /// Channel management mode: `api`, `strategy`, `both`, or `none`
+    #[arg(long, value_enum, default_value_t = ChannelManagement::Api)]
+    pub channel_management: ChannelManagement,
 
     /// REST API host to bind (use "auto" to bind 0.0.0.0 and advertise the container IP)
     #[arg(long, default_value = "localhost")]
@@ -87,6 +87,14 @@ pub struct Args {
     /// hoprd node. Useful for external tooling that needs a funded HOPR identity.
     #[arg(long, default_value_t = DEFAULT_NUM_EXTRA_IDENTITIES, value_parser = parse_extras)]
     pub extra_identities: usize,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum ChannelManagement {
+    Api,
+    Strategy,
+    Both,
+    None,
 }
 
 fn parse_extras(s: &str) -> Result<usize, String> {

--- a/localcluster/src/client_helper.rs
+++ b/localcluster/src/client_helper.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use hoprd_api_client;
+use hoprd_api_client::types::OpenChannelBodyRequest;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use tracing::debug;
 
@@ -84,6 +85,18 @@ impl HoprdApiClient {
 
     pub async fn ping_peer(&self, address: &str) -> Result<()> {
         self.inner.ping_peer(address).await?;
+        Ok(())
+    }
+
+    pub async fn open_channel(&self, destination: &str, amount: &str) -> Result<()> {
+        let body = OpenChannelBodyRequest {
+            amount: amount.to_string(),
+            destination: destination.to_string(),
+        };
+        self.inner
+            .open_channel(&body)
+            .await
+            .map_err(|e| anyhow::anyhow!("open_channel to {destination}: {e}"))?;
         Ok(())
     }
 }
@@ -258,9 +271,6 @@ pub async fn start_nodes(config: &NodeStartConfig<'_>) -> Result<Vec<NodeProcess
 }
 
 /// Poll until every node has an outgoing `Open` channel to every other node.
-///
-/// Channels are opened by the `ChannelLifecycleStrategy` running inside each
-/// hoprd node — no explicit REST `open_channel` calls are made here.
 pub async fn wait_full_mesh_channels(
     nodes: &[NodeProcess],
     timeout: std::time::Duration,
@@ -310,6 +320,62 @@ pub async fn wait_full_mesh_channels(
             let pairs_str: Vec<_> = missing.iter().map(|(s, d)| format!("{s}→{d}")).collect();
             anyhow::bail!(
                 "timeout waiting for full-mesh channels: {}",
+                pairs_str.join(", ")
+            );
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+}
+
+pub async fn open_full_mesh_channels(
+    nodes: &[NodeProcess],
+    amount: &str,
+    timeout: std::time::Duration,
+) -> Result<()> {
+    if let Some(node) = nodes.iter().find(|n| n.address.is_none()) {
+        anyhow::bail!(
+            "node {} address not resolved before opening full-mesh channels",
+            node.id
+        );
+    }
+
+    let start = std::time::Instant::now();
+    loop {
+        let pairs: Vec<_> = nodes
+            .iter()
+            .flat_map(|src| {
+                nodes.iter().filter_map(move |dst| {
+                    let src_addr = src.address.as_deref()?;
+                    let dst_addr = dst.address.as_deref()?;
+                    if src_addr == dst_addr {
+                        return None;
+                    }
+                    Some((src.id, dst.id, src.api.clone(), dst_addr.to_string()))
+                })
+            })
+            .collect();
+
+        let mut missing = Vec::new();
+        for (src, dst, api, addr) in pairs {
+            if api.is_outgoing_channel_open(addr.as_str()).await? {
+                continue;
+            }
+
+            let open_result = api.open_channel(addr.as_str(), amount).await;
+            if open_result.is_err() && !api.is_outgoing_channel_open(addr.as_str()).await? {
+                missing.push((src, dst));
+            }
+        }
+
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        if start.elapsed() > timeout {
+            let pairs_str: Vec<_> = missing.iter().map(|(s, d)| format!("{s}→{d}")).collect();
+            anyhow::bail!(
+                "timeout opening full-mesh channels: {}",
                 pairs_str.join(", ")
             );
         }

--- a/localcluster/src/identity.rs
+++ b/localcluster/src/identity.rs
@@ -63,6 +63,8 @@ pub struct GenerationConfig {
     pub p2p_host: String,
     /// Base P2P port; node `i` listens on `p2p_port_base + i`.
     pub p2p_port_base: u16,
+    /// Enables channel lifecycle strategy in generated hoprd configs.
+    pub enable_channel_strategy: bool,
 }
 
 impl Default for GenerationConfig {
@@ -77,6 +79,7 @@ impl Default for GenerationConfig {
             num_extras: DEFAULT_NUM_EXTRA_IDENTITIES,
             p2p_host: "127.0.0.1".to_string(),
             p2p_port_base: 9000,
+            enable_channel_strategy: false,
         }
     }
 }
@@ -208,30 +211,29 @@ pub async fn generate(config: &GenerationConfig) -> anyhow::Result<GenerationOut
     let initial_native_balance: XDaiBalance = "1 xDai".parse()?;
     let p2p_host = &config.p2p_host;
 
-    // Set population thresholds to the exact cluster mesh size so the
-    // ChannelLifecycleStrategy opens a channel to every other node.
     let effective_num_nodes = config.num_nodes.clamp(1, NODE_KEYS.len());
-    let mesh_target = effective_num_nodes.saturating_sub(1);
+    let mut strategies = vec![StrategyKind::AutoRedeeming(AutoRedeemingStrategyConfig {
+        redeem_on_winning: true,
+        ..Default::default()
+    })];
+    if config.enable_channel_strategy {
+        let mesh_target = effective_num_nodes.saturating_sub(1);
+        strategies.push(StrategyKind::ChannelLifecycle(ChannelLifecycleConfig {
+            population: PopulationConfig {
+                min_open_channels: mesh_target,
+                target_open_channels: mesh_target,
+                ..Default::default()
+            },
+            // probe_recheck_threshold=3s → first probe within 3s → EMA converges
+            // immediately → peer_score ≥ 0.5 well before this 10s tick fires.
+            tick_interval: std::time::Duration::from_secs(10),
+            ..Default::default()
+        }));
+    }
     let node_strategy = MultiStrategyConfig {
         allow_recursive: false,
         execution_interval: std::time::Duration::from_secs(60),
-        strategies: vec![
-            StrategyKind::AutoRedeeming(AutoRedeemingStrategyConfig {
-                redeem_on_winning: true,
-                ..Default::default()
-            }),
-            StrategyKind::ChannelLifecycle(ChannelLifecycleConfig {
-                population: PopulationConfig {
-                    min_open_channels: mesh_target,
-                    target_open_channels: mesh_target,
-                    ..Default::default()
-                },
-                // probe_recheck_threshold=3s → first probe within 3s → EMA converges
-                // immediately → peer_score ≥ 0.5 well before this 10s tick fires.
-                tick_interval: std::time::Duration::from_secs(10),
-                ..Default::default()
-            }),
-        ],
+        strategies,
     };
 
     let mut nodes = Vec::with_capacity(effective_num_nodes);

--- a/localcluster/src/main.rs
+++ b/localcluster/src/main.rs
@@ -5,7 +5,7 @@
 //! 2. Generate node identities and fund Safes on-chain (`identity::generate`).
 //! 3. Spawn `hoprd` processes, one per node.
 //! 4. Wait for each node to pass `/startedz` then `/readyz`.
-//! 5. Wait for the `ChannelLifecycleStrategy` to open the full-mesh channel topology.
+//! 5. Manage channels according to `--channel-management`.
 //! 6. Block until Ctrl-C, then shut everything down.
 //!
 //! See `docs/localcluster/README.md` for full setup and usage instructions.
@@ -21,6 +21,7 @@ use hoprd_localcluster::{
 use tracing::{error, info, warn};
 
 const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_CHANNEL_STAKE: &str = "1 wxHOPR";
 
 #[derive(Default)]
 struct Cleanup {
@@ -87,6 +88,10 @@ async fn main() -> Result<()> {
             num_extras: args.extra_identities,
             p2p_host: args.p2p_host.clone(),
             p2p_port_base: args.p2p_port_base,
+            enable_channel_strategy: matches!(
+                args.channel_management,
+                cli::ChannelManagement::Strategy | cli::ChannelManagement::Both
+            ),
             ..Default::default()
         };
 
@@ -134,14 +139,42 @@ async fn main() -> Result<()> {
             node.address = Some(node.api.addresses().await?);
         }
 
-        if args.skip_channels {
-            warn!("skipping channel topology wait");
-        } else {
-            info!("waiting for full-mesh peer visibility");
-            client_helper::wait_full_mesh_reachable(&cleanup.nodes, DEFAULT_WAIT_TIMEOUT).await?;
-            info!("waiting for channel-lifecycle strategy to open the full mesh");
-            client_helper::wait_full_mesh_channels(&cleanup.nodes, DEFAULT_WAIT_TIMEOUT * 4)
+        match args.channel_management {
+            cli::ChannelManagement::None => {
+                warn!("channel management is disabled");
+            }
+            cli::ChannelManagement::Api => {
+                info!("opening full-mesh channels through REST API");
+                client_helper::open_full_mesh_channels(
+                    &cleanup.nodes,
+                    DEFAULT_CHANNEL_STAKE,
+                    DEFAULT_WAIT_TIMEOUT * 4,
+                )
                 .await?;
+                info!("waiting for full-mesh channels to be open");
+                client_helper::wait_full_mesh_channels(&cleanup.nodes, DEFAULT_WAIT_TIMEOUT * 4)
+                    .await?;
+            }
+            cli::ChannelManagement::Strategy => {
+                info!("waiting for full-mesh peer visibility");
+                client_helper::wait_full_mesh_reachable(&cleanup.nodes, DEFAULT_WAIT_TIMEOUT)
+                    .await?;
+                info!("waiting for strategy-managed full-mesh channels");
+                client_helper::wait_full_mesh_channels(&cleanup.nodes, DEFAULT_WAIT_TIMEOUT * 4)
+                    .await?;
+            }
+            cli::ChannelManagement::Both => {
+                info!("opening full-mesh channels through REST API");
+                client_helper::open_full_mesh_channels(
+                    &cleanup.nodes,
+                    DEFAULT_CHANNEL_STAKE,
+                    DEFAULT_WAIT_TIMEOUT * 4,
+                )
+                .await?;
+                info!("waiting for full-mesh channels to be open");
+                client_helper::wait_full_mesh_channels(&cleanup.nodes, DEFAULT_WAIT_TIMEOUT * 4)
+                    .await?;
+            }
         }
 
         node_summary(&cleanup.nodes, &args, &blokli_url);

--- a/localcluster/src/main.rs
+++ b/localcluster/src/main.rs
@@ -21,7 +21,6 @@ use hoprd_localcluster::{
 use tracing::{error, info, warn};
 
 const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
-const DEFAULT_CHANNEL_STAKE: &str = "1 wxHOPR";
 
 #[derive(Default)]
 struct Cleanup {
@@ -147,7 +146,7 @@ async fn main() -> Result<()> {
                 info!("opening full-mesh channels through REST API");
                 client_helper::open_full_mesh_channels(
                     &cleanup.nodes,
-                    DEFAULT_CHANNEL_STAKE,
+                    &args.funding_amount,
                     DEFAULT_WAIT_TIMEOUT * 4,
                 )
                 .await?;
@@ -167,7 +166,7 @@ async fn main() -> Result<()> {
                 info!("opening full-mesh channels through REST API");
                 client_helper::open_full_mesh_channels(
                     &cleanup.nodes,
-                    DEFAULT_CHANNEL_STAKE,
+                    &args.funding_amount,
                     DEFAULT_WAIT_TIMEOUT * 4,
                 )
                 .await?;


### PR DESCRIPTION
The localcluster now allow to choose how the full-mesh will be achieved:
- using the rest-api calls: `--channel-management api`. This disables the channel lifecycle strategy completely
- using the channel lifecycle strategy: `--channel-management strategy`. No API calls involved
- using both the rest-api call + the strategy: `--channel-management both`. The RestAPI calls opens the inital channel fast, then the strategy would manage the channel further
- no channel being automatically opened: `--channel-management none`. No channel lifecycle strategy, no full mesh.

By default, the localcluster opens channel using  `--channel-management api`. This allows the cluster to start fast.