### PR TITLE
feat(container): validate hoprd config file before launch in Docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4914,6 +4914,7 @@ dependencies = [
  "hoprd-api",
  "humansize",
  "humantime-serde",
+ "if-addrs",
  "lazy_static",
  "mimalloc",
  "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4894,7 +4894,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd"
-version = "4.0.3-rc.5"
+version = "4.0.3-rc.4"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4428,8 +4428,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.3-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+version = "4.0.2-rc.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4635,8 +4635,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+version = "0.28.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4677,8 +4677,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-mixer"
-version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+version = "0.4.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4693,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4771,7 +4771,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4838,7 +4838,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4868,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4894,7 +4894,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd"
-version = "4.0.3-rc.4"
+version = "4.0.3-rc.5"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ http = "1.4.0"
 human-bandwidth = { version = "0.1.4", features = ["serde"] }
 humansize = "2.1.3"
 humantime-serde = "1.1.1"
+if-addrs = "0.15.0"
 lazy_static = "1.5.0"
 mockall = "0.14.0"
 mimalloc = { version = "0.1.50", default-features = false, features = [

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -25,6 +25,13 @@ fi
 # overrides) exactly as hoprd builds it at startup, so misconfigurations fail
 # fast before launch. hoprd-cfg surfaces missing-file errors and treats a
 # --help/--version request as a no-op success.
-RUST_BACKTRACE=0 /bin/hoprd-cfg --validate-args -- "$@"
+echo "hoprd container startup attempt: validating configuration" >&2
+if RUST_BACKTRACE=0 /bin/hoprd-cfg --validate-args -- "$@"; then
+  echo "hoprd container startup attempt: configuration valid; launching hoprd" >&2
+else
+  exit_code=$?
+  echo "hoprd container startup attempt: configuration validation failed; exiting with status ${exit_code}. A configured container restart policy may launch another attempt." >&2
+  exit "$exit_code"
+fi
 
 exec /bin/hoprd "$@"

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -43,11 +43,13 @@ fi
 export HOPRD_DEFAULT_SESSION_LISTEN_HOST="$listen_host"
 
 # Resolve the hoprd configuration file path from CLI args or env var.
+# Mirrors clap's last-wins semantics: if --configurationFilePath appears
+# multiple times, the last valid value is used.
 # Returns 2 (with an error message to stderr) when --configurationFilePath
 # is present but has no value, so the caller never silently falls back to
 # the env var in that case.
 resolve_config_path() {
-  local prev="" arg
+  local found_val="" prev="" arg
   for arg in "$@"; do
     case "$arg" in
     --configurationFilePath=*)
@@ -56,8 +58,9 @@ resolve_config_path() {
         echo "Error: --configurationFilePath requires a non-empty value" >&2
         return 2
       fi
-      echo "$val"
-      return 0
+      found_val="$val"
+      prev=""
+      continue
       ;;
     --configurationFilePath)
       prev="match"
@@ -72,15 +75,20 @@ resolve_config_path() {
         return 2
         ;;
       esac
-      echo "$arg"
-      return 0
+      found_val="$arg"
+      prev=""
+      continue
     fi
   done
   if [ "$prev" = "match" ]; then
     echo "Error: --configurationFilePath requires a non-empty value" >&2
     return 2
   fi
-  echo "${HOPRD_CONFIGURATION_FILE_PATH:-}"
+  if [ -n "$found_val" ]; then
+    echo "$found_val"
+  else
+    echo "${HOPRD_CONFIGURATION_FILE_PATH:-}"
+  fi
   return 0
 }
 
@@ -90,16 +98,16 @@ resolve_config_path() {
 # the /bin/ boundary.
 _cmd="${1:-}"
 case "$_cmd" in
-  "" | hoprd | */*)
+"" | hoprd | */*)
+  _is_escape_hatch=0
+  ;;
+*)
+  if [ -f "/bin/$_cmd" ] && [ -x "/bin/$_cmd" ]; then
+    _is_escape_hatch=1
+  else
     _is_escape_hatch=0
-    ;;
-  *)
-    if [ -f "/bin/$_cmd" ] && [ -x "/bin/$_cmd" ]; then
-      _is_escape_hatch=1
-    else
-      _is_escape_hatch=0
-    fi
-    ;;
+  fi
+  ;;
 esac
 
 # Validate the config file when hoprd is about to run.
@@ -113,6 +121,9 @@ fi
 
 if [ "$_is_escape_hatch" -eq 1 ]; then
   exec "/bin/$_cmd" "${@:2}"
+elif [ "$_cmd" = "hoprd" ]; then
+  # Default Cmd is ["hoprd"], so $1 is the command name, not a flag — strip it.
+  exec /bin/hoprd "${@:2}"
 else
   exec /bin/hoprd "$@"
 fi

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -84,18 +84,35 @@ resolve_config_path() {
   return 0
 }
 
+# Determine whether the first argument names a plain binary in /bin/.
+# Reject values containing '/' (absolute paths, path traversal) so that
+# /bin/${1} is always a safe single-level lookup and users cannot escape
+# the /bin/ boundary.
+_cmd="${1:-}"
+case "$_cmd" in
+  "" | hoprd | */*)
+    _is_escape_hatch=0
+    ;;
+  *)
+    if [ -f "/bin/$_cmd" ] && [ -x "/bin/$_cmd" ]; then
+      _is_escape_hatch=1
+    else
+      _is_escape_hatch=0
+    fi
+    ;;
+esac
+
 # Validate the config file when hoprd is about to run.
-# The escape hatch (exec "$@" for another /bin/ binary) skips validation.
 # Missing-file errors are surfaced by hoprd-cfg itself for consistent output.
-if [ -z "${1:-}" ] || [ ! -f "/bin/${1:-}" ] || [ ! -x "/bin/${1:-}" ] || [ "${1:-}" = "hoprd" ]; then
+if [ "$_is_escape_hatch" -eq 0 ]; then
   cfg_path="$(resolve_config_path "$@")" || exit $?
   if [ -n "$cfg_path" ]; then
     /bin/hoprd-cfg --validate "$cfg_path"
   fi
 fi
 
-if [ -n "${1:-}" ] && [ -f "/bin/${1:-}" ] && [ -x "/bin/${1:-}" ]; then
-  exec "/bin/$1" "${@:2}"
+if [ "$_is_escape_hatch" -eq 1 ]; then
+  exec "/bin/$_cmd" "${@:2}"
 else
   exec /bin/hoprd "$@"
 fi

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -77,7 +77,7 @@ resolve_config_path() {
     fi
   done
   if [ "$prev" = "match" ]; then
-    echo "Error: --configurationFilePath requires a value" >&2
+    echo "Error: --configurationFilePath requires a non-empty value" >&2
     return 2
   fi
   echo "${HOPRD_CONFIGURATION_FILE_PATH:-}"
@@ -95,7 +95,7 @@ if [ -z "${1:-}" ] || [ ! -f "/bin/${1:-}" ] || [ ! -x "/bin/${1:-}" ] || [ "${1
 fi
 
 if [ -n "${1:-}" ] && [ -f "/bin/${1:-}" ] && [ -x "/bin/${1:-}" ]; then
-  exec "$@"
+  exec "/bin/$1" "${@:2}"
 else
   exec /bin/hoprd "$@"
 fi

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -65,6 +65,13 @@ resolve_config_path() {
       ;;
     esac
     if [ "$prev" = "match" ]; then
+      # Treat an empty value or another flag as a missing value.
+      case "$arg" in
+      "" | --*)
+        echo "Error: --configurationFilePath requires a non-empty value" >&2
+        return 2
+        ;;
+      esac
       echo "$arg"
       return 0
     fi
@@ -81,7 +88,7 @@ resolve_config_path() {
 # The escape hatch (exec "$@" for another /bin/ binary) skips validation.
 # Missing-file errors are surfaced by hoprd-cfg itself for consistent output.
 if [ -z "${1:-}" ] || [ ! -f "/bin/${1:-}" ] || [ ! -x "/bin/${1:-}" ] || [ "${1:-}" = "hoprd" ]; then
-  cfg_path="$(resolve_config_path "$@")" || exit 1
+  cfg_path="$(resolve_config_path "$@")" || exit $?
   if [ -n "$cfg_path" ]; then
     /bin/hoprd-cfg --validate "$cfg_path"
   fi

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -1,129 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Locate the CA bundle provided by pkgs.cacert (present in extraContents).
-for candidate in \
-  /etc/ssl/certs/ca-bundle.crt \
-  /etc/ssl/certs/ca-certificates.crt; do
-  if [ -f "$candidate" ]; then
-    export SSL_CERT_FILE="$candidate"
-    export NIX_SSL_CERT_FILE="$candidate"
-    break
-  fi
-done
-
-mkdir -p "$TMPDIR"
-
-# Resolve the session listen host, filling in the container IP when not set.
-listen_host="${HOPRD_DEFAULT_SESSION_LISTEN_HOST:-}"
-case "$listen_host" in
-*:*)
-  listen_host_preset_ip="${listen_host%%:*}"
-  listen_host_preset_port="${listen_host#*:}"
-  ;;
-*)
-  listen_host_preset_ip="$listen_host"
-  listen_host_preset_port=""
-  ;;
-esac
-
-if [ -z "${listen_host_preset_ip:-}" ]; then
-  listen_host_ip="$(hostname -i | {
-    read -r first _rest
-    echo "$first"
-  })"
-
-  if [ -z "${listen_host_preset_port:-}" ]; then
-    listen_host="${listen_host_ip}:0"
-  else
-    listen_host="${listen_host_ip}:${listen_host_preset_port}"
-  fi
-fi
-
-export HOPRD_DEFAULT_SESSION_LISTEN_HOST="$listen_host"
-
-# Resolve the hoprd configuration file path from CLI args or env var.
-# Mirrors clap's last-wins semantics: if --configurationFilePath appears
-# multiple times, the last valid value is used.
-# Returns 2 (with an error message to stderr) when --configurationFilePath
-# is present but has no value, so the caller never silently falls back to
-# the env var in that case.
-resolve_config_path() {
-  local found_val="" prev="" arg
-  for arg in "$@"; do
-    case "$arg" in
-    --configurationFilePath=*)
-      local val="${arg#*=}"
-      if [ -z "$val" ]; then
-        echo "Error: --configurationFilePath requires a non-empty value" >&2
-        return 2
-      fi
-      found_val="$val"
-      prev=""
-      continue
-      ;;
-    --configurationFilePath)
-      prev="match"
-      continue
-      ;;
-    esac
-    if [ "$prev" = "match" ]; then
-      # Treat an empty value or another flag as a missing value.
-      case "$arg" in
-      "" | --*)
-        echo "Error: --configurationFilePath requires a non-empty value" >&2
-        return 2
-        ;;
-      esac
-      found_val="$arg"
-      prev=""
-      continue
-    fi
-  done
-  if [ "$prev" = "match" ]; then
-    echo "Error: --configurationFilePath requires a non-empty value" >&2
-    return 2
-  fi
-  if [ -n "$found_val" ]; then
-    echo "$found_val"
-  else
-    echo "${HOPRD_CONFIGURATION_FILE_PATH:-}"
-  fi
-  return 0
-}
-
-# Determine whether the first argument names a plain binary in /bin/.
-# Reject values containing '/' (absolute paths, path traversal) so that
-# /bin/${1} is always a safe single-level lookup and users cannot escape
-# the /bin/ boundary.
+# Determine whether the first argument names a plain binary in /bin/. This is an
+# escape hatch for debugging (e.g. `docker run <image> bash`). Reject values
+# containing '/' (absolute paths, path traversal) so that /bin/${1} is always a
+# safe single-level lookup and users cannot escape the /bin/ boundary.
 _cmd="${1:-}"
 case "$_cmd" in
-"" | hoprd | */*)
-  _is_escape_hatch=0
-  ;;
+"" | hoprd | */*) ;;
 *)
   if [ -f "/bin/$_cmd" ] && [ -x "/bin/$_cmd" ]; then
-    _is_escape_hatch=1
-  else
-    _is_escape_hatch=0
+    exec "/bin/$_cmd" "${@:2}"
   fi
   ;;
 esac
 
-# Validate the config file when hoprd is about to run.
-# Missing-file errors are surfaced by hoprd-cfg itself for consistent output.
-if [ "$_is_escape_hatch" -eq 0 ]; then
-  cfg_path="$(resolve_config_path "$@")" || exit $?
-  if [ -n "$cfg_path" ]; then
-    RUST_BACKTRACE=0 /bin/hoprd-cfg --validate "$cfg_path"
-  fi
+# The default Cmd is ["hoprd"], so when present the command word is $1, not a
+# flag; strip it so "$@" is the exact argument vector hoprd will receive.
+if [ "$_cmd" = "hoprd" ]; then
+  shift
 fi
 
-if [ "$_is_escape_hatch" -eq 1 ]; then
-  exec "/bin/$_cmd" "${@:2}"
-elif [ "$_cmd" = "hoprd" ]; then
-  # Default Cmd is ["hoprd"], so $1 is the command name, not a flag — strip it.
-  exec /bin/hoprd "${@:2}"
-else
-  exec /bin/hoprd "$@"
-fi
+# Validate the effective configuration (YAML file plus env-var and CLI-flag
+# overrides) exactly as hoprd builds it at startup, so misconfigurations fail
+# fast before launch. hoprd-cfg surfaces missing-file errors and treats a
+# --help/--version request as a no-op success.
+RUST_BACKTRACE=0 /bin/hoprd-cfg --validate-args -- "$@"
+
+exec /bin/hoprd "$@"

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -115,7 +115,7 @@ esac
 if [ "$_is_escape_hatch" -eq 0 ]; then
   cfg_path="$(resolve_config_path "$@")" || exit $?
   if [ -n "$cfg_path" ]; then
-    /bin/hoprd-cfg --validate "$cfg_path"
+    RUST_BACKTRACE=0 /bin/hoprd-cfg --validate "$cfg_path"
   fi
 fi
 

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Locate the CA bundle provided by pkgs.cacert (present in extraContents).
+for candidate in \
+  /etc/ssl/certs/ca-bundle.crt \
+  /etc/ssl/certs/ca-certificates.crt; do
+  if [ -f "$candidate" ]; then
+    export SSL_CERT_FILE="$candidate"
+    export NIX_SSL_CERT_FILE="$candidate"
+    break
+  fi
+done
+
+mkdir -p "$TMPDIR"
+
+# Resolve the session listen host, filling in the container IP when not set.
+listen_host="${HOPRD_DEFAULT_SESSION_LISTEN_HOST:-}"
+case "$listen_host" in
+*:*)
+  listen_host_preset_ip="${listen_host%%:*}"
+  listen_host_preset_port="${listen_host#*:}"
+  ;;
+*)
+  listen_host_preset_ip="$listen_host"
+  listen_host_preset_port=""
+  ;;
+esac
+
+if [ -z "${listen_host_preset_ip:-}" ]; then
+  listen_host_ip="$(hostname -i | {
+    read -r first _rest
+    echo "$first"
+  })"
+
+  if [ -z "${listen_host_preset_port:-}" ]; then
+    listen_host="${listen_host_ip}:0"
+  else
+    listen_host="${listen_host_ip}:${listen_host_preset_port}"
+  fi
+fi
+
+export HOPRD_DEFAULT_SESSION_LISTEN_HOST="$listen_host"
+
+# Resolve the hoprd configuration file path from CLI args or env var.
+# Returns 2 (with an error message to stderr) when --configurationFilePath
+# is present but has no value, so the caller never silently falls back to
+# the env var in that case.
+resolve_config_path() {
+  local prev="" arg
+  for arg in "$@"; do
+    case "$arg" in
+    --configurationFilePath=*)
+      local val="${arg#*=}"
+      if [ -z "$val" ]; then
+        echo "Error: --configurationFilePath requires a non-empty value" >&2
+        return 2
+      fi
+      echo "$val"
+      return 0
+      ;;
+    --configurationFilePath)
+      prev="match"
+      continue
+      ;;
+    esac
+    if [ "$prev" = "match" ]; then
+      echo "$arg"
+      return 0
+    fi
+  done
+  if [ "$prev" = "match" ]; then
+    echo "Error: --configurationFilePath requires a value" >&2
+    return 2
+  fi
+  echo "${HOPRD_CONFIGURATION_FILE_PATH:-}"
+  return 0
+}
+
+# Validate the config file when hoprd is about to run.
+# The escape hatch (exec "$@" for another /bin/ binary) skips validation.
+# Missing-file errors are surfaced by hoprd-cfg itself for consistent output.
+if [ -z "${1:-}" ] || [ ! -f "/bin/${1:-}" ] || [ ! -x "/bin/${1:-}" ] || [ "${1:-}" = "hoprd" ]; then
+  cfg_path="$(resolve_config_path "$@")" || exit 1
+  if [ -n "$cfg_path" ]; then
+    /bin/hoprd-cfg --validate "$cfg_path"
+  fi
+fi
+
+if [ -n "${1:-}" ] && [ -f "/bin/${1:-}" ] && [ -x "/bin/${1:-}" ]; then
+  exec "$@"
+else
+  exec /bin/hoprd "$@"
+fi

--- a/flake.nix
+++ b/flake.nix
@@ -366,7 +366,12 @@
               ];
               Entrypoint = [ "/bin/docker-entrypoint.sh" ];
               Cmd = [ "hoprd" ];
-              env = [ "TMPDIR=/app/.tmp" ];
+              env = [
+                "TMPDIR=/app/.tmp"
+                "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "HOPRD_DEFAULT_SESSION_LISTEN_HOST=auto:0"
+              ];
             };
             docker-hoprd-dev-x86_64-linux = nixLib.mkDockerImage {
               name = "hoprd";
@@ -378,7 +383,12 @@
               ];
               Entrypoint = [ "/bin/docker-entrypoint.sh" ];
               Cmd = [ "hoprd" ];
-              env = [ "TMPDIR=/app/.tmp" ];
+              env = [
+                "TMPDIR=/app/.tmp"
+                "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "HOPRD_DEFAULT_SESSION_LISTEN_HOST=auto:0"
+              ];
             };
             docker-hoprd-profile-x86_64-linux = nixLib.mkDockerImage {
               name = "hoprd";
@@ -401,6 +411,9 @@
               Cmd = [ "hoprd" ];
               env = [
                 "TMPDIR=/app/.tmp"
+                "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "HOPRD_DEFAULT_SESSION_LISTEN_HOST=auto:0"
                 "_RJEM_MALLOC_CONF=prof:true,prof_active:true,prof_final:true,prof_prefix=/app/.tmp/jeprof,lg_prof_sample:19"
               ];
             };
@@ -414,7 +427,12 @@
               ];
               Entrypoint = [ "/bin/docker-entrypoint.sh" ];
               Cmd = [ "hoprd" ];
-              env = [ "TMPDIR=/app/.tmp" ];
+              env = [
+                "TMPDIR=/app/.tmp"
+                "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "HOPRD_DEFAULT_SESSION_LISTEN_HOST=auto:0"
+              ];
             };
             docker-hoprd-localcluster-x86_64-linux = nixLib.mkDockerImage {
               name = "hoprd-localcluster";

--- a/flake.nix
+++ b/flake.nix
@@ -358,13 +358,22 @@
           hoprdDocker = {
             docker-hoprd-x86_64-linux = nixLib.mkDockerImage {
               name = "hoprd";
+              pathsToLink = [
+                "/bin"
+                "/etc"
+              ];
               extraContents = [
                 dockerHoprdEntrypoint
+                pkgs.tini
                 hoprdPackages.binary-hoprd-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
-              Entrypoint = [ "/bin/docker-entrypoint.sh" ];
+              Entrypoint = [
+                "/bin/tini"
+                "--"
+                "/bin/docker-entrypoint.sh"
+              ];
               Cmd = [ "hoprd" ];
               env = [
                 "TMPDIR=/app/.tmp"
@@ -375,13 +384,22 @@
             };
             docker-hoprd-dev-x86_64-linux = nixLib.mkDockerImage {
               name = "hoprd";
+              pathsToLink = [
+                "/bin"
+                "/etc"
+              ];
               extraContents = [
                 dockerHoprdEntrypoint
+                pkgs.tini
                 hoprdPackages.binary-hoprd-dev-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
-              Entrypoint = [ "/bin/docker-entrypoint.sh" ];
+              Entrypoint = [
+                "/bin/tini"
+                "--"
+                "/bin/docker-entrypoint.sh"
+              ];
               Cmd = [ "hoprd" ];
               env = [
                 "TMPDIR=/app/.tmp"
@@ -392,8 +410,13 @@
             };
             docker-hoprd-profile-x86_64-linux = nixLib.mkDockerImage {
               name = "hoprd";
+              pathsToLink = [
+                "/bin"
+                "/etc"
+              ];
               extraContents = [
                 dockerHoprdEntrypoint
+                pkgs.tini
                 hoprdPackages.binary-hoprd-profile-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
@@ -407,7 +430,11 @@
                 pkgs.perl
               ]
               ++ profileDeps;
-              Entrypoint = [ "/bin/docker-entrypoint.sh" ];
+              Entrypoint = [
+                "/bin/tini"
+                "--"
+                "/bin/docker-entrypoint.sh"
+              ];
               Cmd = [ "hoprd" ];
               env = [
                 "TMPDIR=/app/.tmp"
@@ -419,13 +446,22 @@
             };
             docker-hoprd-aarch64-linux = nixLib.mkDockerImage {
               name = "hoprd";
+              pathsToLink = [
+                "/bin"
+                "/etc"
+              ];
               extraContents = [
                 dockerHoprdEntrypoint
+                pkgs.tini
                 hoprdPackages.binary-hoprd-aarch64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
-              Entrypoint = [ "/bin/docker-entrypoint.sh" ];
+              Entrypoint = [
+                "/bin/tini"
+                "--"
+                "/bin/docker-entrypoint.sh"
+              ];
               Cmd = [ "hoprd" ];
               env = [
                 "TMPDIR=/app/.tmp"
@@ -436,6 +472,10 @@
             };
             docker-hoprd-localcluster-x86_64-linux = nixLib.mkDockerImage {
               name = "hoprd-localcluster";
+              pathsToLink = [
+                "/bin"
+                "/etc"
+              ];
               extraContents = [
                 hoprdPackages.binary-hoprd-x86_64-linux
                 hoprdPackages.binary-hoprd-localcluster-x86_64-linux

--- a/flake.nix
+++ b/flake.nix
@@ -341,10 +341,9 @@
                 }
               );
 
-          dockerHoprdEntrypoint = pkgs.writeShellApplication {
-            name = "docker-entrypoint.sh";
-            text = builtins.readFile ./deploy/docker/docker-entrypoint.sh;
-          };
+          dockerHoprdEntrypoint = pkgs.writeShellScriptBin "docker-entrypoint.sh" (
+            builtins.readFile ./deploy/docker/docker-entrypoint.sh
+          );
 
           analyzeMemoryScript = pkgs.writeShellScriptBin "analyze_memory.sh" (
             builtins.readFile ./profiling/analyze_memory.sh
@@ -592,7 +591,18 @@
             };
           };
 
-          checks = { inherit (hoprdPackages) hoprd-clippy; };
+          checks = {
+            inherit (hoprdPackages) hoprd-clippy;
+            shellcheck-docker-entrypoint =
+              pkgs.runCommand "shellcheck-docker-entrypoint"
+                {
+                  nativeBuildInputs = [ pkgs.shellcheck ];
+                }
+                ''
+                  shellcheck ${./deploy/docker/docker-entrypoint.sh}
+                  touch $out
+                '';
+          };
 
           apps = {
             check = run-check;

--- a/flake.nix
+++ b/flake.nix
@@ -376,6 +376,29 @@
 
             export HOPRD_DEFAULT_SESSION_LISTEN_HOST="''${listen_host}"
 
+            resolve_config_path() {
+              local prev="" arg
+              for arg in "$@"; do
+                case "$arg" in
+                  --configurationFilePath=*) echo "''${arg#*=}"; return ;;
+                  --configurationFilePath)   prev="match"; continue ;;
+                esac
+                if [ "$prev" = "match" ]; then echo "$arg"; return; fi
+              done
+              echo "''${HOPRD_CONFIGURATION_FILE_PATH:-}"
+            }
+
+            if [ -z "''${1:-}" ] || [ ! -f "/bin/''${1:-}" ] || [ ! -x "/bin/''${1:-}" ] || [ "''${1:-}" = "hoprd" ]; then
+              cfg_path="$(resolve_config_path "$@")"
+              if [ -n "$cfg_path" ]; then
+                if [ ! -f "$cfg_path" ]; then
+                  echo "hoprd-cfg: configuration file '$cfg_path' not found" >&2
+                  exit 1
+                fi
+                /bin/hoprd-cfg --validate "$cfg_path"
+              fi
+            fi
+
             if [ -n "''${1:-}" ] && [ -f "/bin/''${1:-}" ] && [ -x "/bin/''${1:-}" ]; then
               exec "$@"
             else
@@ -399,6 +422,7 @@
               extraContents = [
                 dockerHoprdEntrypoint
                 hoprdPackages.binary-hoprd-x86_64-linux
+                hoprdPackages.binary-hoprd-cfg-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -411,6 +435,7 @@
               extraContents = [
                 dockerHoprdEntrypoint
                 hoprdPackages.binary-hoprd-dev-x86_64-linux
+                hoprdPackages.binary-hoprd-cfg-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -423,6 +448,7 @@
               extraContents = [
                 dockerHoprdEntrypoint
                 hoprdPackages.binary-hoprd-profile-x86_64-linux
+                hoprdPackages.binary-hoprd-cfg-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
                 analyzeMemoryScript
@@ -447,6 +473,7 @@
               extraContents = [
                 dockerHoprdEntrypoint
                 hoprdPackages.binary-hoprd-aarch64-linux
+                hoprdPackages.binary-hoprd-cfg-aarch64-linux
                 pkgs.cacert
                 pkgs.curl
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -361,7 +361,6 @@
               extraContents = [
                 dockerHoprdEntrypoint
                 hoprdPackages.binary-hoprd-x86_64-linux
-                hoprdPackages.binary-hoprd-cfg-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -374,7 +373,6 @@
               extraContents = [
                 dockerHoprdEntrypoint
                 hoprdPackages.binary-hoprd-dev-x86_64-linux
-                hoprdPackages.binary-hoprd-cfg-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -387,7 +385,6 @@
               extraContents = [
                 dockerHoprdEntrypoint
                 hoprdPackages.binary-hoprd-profile-x86_64-linux
-                hoprdPackages.binary-hoprd-cfg-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
                 analyzeMemoryScript
@@ -412,7 +409,6 @@
               extraContents = [
                 dockerHoprdEntrypoint
                 hoprdPackages.binary-hoprd-aarch64-linux
-                hoprdPackages.binary-hoprd-cfg-aarch64-linux
                 pkgs.cacert
                 pkgs.curl
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -341,70 +341,10 @@
                 }
               );
 
-          dockerHoprdEntrypoint = pkgs.writeShellScriptBin "docker-entrypoint.sh" ''
-            set -euo pipefail
-
-            ssl_cert_file="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-            if [ -f "$ssl_cert_file" ]; then
-              export SSL_CERT_FILE="$ssl_cert_file"
-              export NIX_SSL_CERT_FILE="$ssl_cert_file"
-            fi
-
-            mkdir -p "$TMPDIR"
-
-            listen_host="''${HOPRD_DEFAULT_SESSION_LISTEN_HOST:-}"
-            case "''${listen_host}" in
-              *:*)
-                listen_host_preset_ip="''${listen_host%%:*}"
-                listen_host_preset_port="''${listen_host#*:}"
-                ;;
-              *)
-                listen_host_preset_ip="''${listen_host}"
-                listen_host_preset_port=""
-                ;;
-            esac
-
-            if [ -z "''${listen_host_preset_ip:-}" ]; then
-              listen_host_ip="$(hostname -i | { read -r first _rest; echo "$first"; })"
-
-              if [ -z "''${listen_host_preset_port:-}" ]; then
-                listen_host="''${listen_host_ip}:0"
-              else
-                listen_host="''${listen_host_ip}:''${listen_host_preset_port}"
-              fi
-            fi
-
-            export HOPRD_DEFAULT_SESSION_LISTEN_HOST="''${listen_host}"
-
-            resolve_config_path() {
-              local prev="" arg
-              for arg in "$@"; do
-                case "$arg" in
-                  --configurationFilePath=*) echo "''${arg#*=}"; return ;;
-                  --configurationFilePath)   prev="match"; continue ;;
-                esac
-                if [ "$prev" = "match" ]; then echo "$arg"; return; fi
-              done
-              echo "''${HOPRD_CONFIGURATION_FILE_PATH:-}"
-            }
-
-            if [ -z "''${1:-}" ] || [ ! -f "/bin/''${1:-}" ] || [ ! -x "/bin/''${1:-}" ] || [ "''${1:-}" = "hoprd" ]; then
-              cfg_path="$(resolve_config_path "$@")"
-              if [ -n "$cfg_path" ]; then
-                if [ ! -f "$cfg_path" ]; then
-                  echo "hoprd-cfg: configuration file '$cfg_path' not found" >&2
-                  exit 1
-                fi
-                /bin/hoprd-cfg --validate "$cfg_path"
-              fi
-            fi
-
-            if [ -n "''${1:-}" ] && [ -f "/bin/''${1:-}" ] && [ -x "/bin/''${1:-}" ]; then
-              exec "$@"
-            else
-              exec /bin/hoprd "$@"
-            fi
-          '';
+          dockerHoprdEntrypoint = pkgs.writeShellApplication {
+            name = "docker-entrypoint.sh";
+            text = builtins.readFile ./deploy/docker/docker-entrypoint.sh;
+          };
 
           analyzeMemoryScript = pkgs.writeShellScriptBin "analyze_memory.sh" (
             builtins.readFile ./profiling/analyze_memory.sh

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -82,6 +82,7 @@ console-subscriber = { workspace = true, optional = true }
 futures = { workspace = true }
 flagset = { workspace = true, optional = true }
 home = { workspace = true }
+if-addrs = { workspace = true }
 humansize = { workspace = true, optional = true, features = ["no_alloc"] }
 humantime-serde = { workspace = true }
 proc-macro-regex = { workspace = true }

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd"
-version = "4.0.3-rc.4"
+version = "4.0.3-rc.5"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd"
-version = "4.0.3-rc.5"
+version = "4.0.3-rc.4"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/hoprd/src/bin/hoprd-cfg.rs
+++ b/hoprd/src/bin/hoprd-cfg.rs
@@ -83,12 +83,9 @@ fn main() -> anyhow::Result<()> {
         // are applied exactly as hoprd would apply them at startup.  Without this,
         // fields legitimately supplied via environment variables (the standard Docker
         // Compose pattern) would always fail validation.
-        let hoprd_args = hoprd::cli::CliArgs::try_parse_from([
-            "hoprd",
-            "--configurationFilePath",
-            &cfg_path,
-        ])
-        .context("failed to parse args for validation")?;
+        let hoprd_args =
+            hoprd::cli::CliArgs::try_parse_from(["hoprd", "--configurationFilePath", &cfg_path])
+                .context("failed to parse args for validation")?;
         let cfg = HoprdConfig::try_from(hoprd_args).context("failed to build config")?;
 
         cfg.validate().context("config validation failed")?;
@@ -111,12 +108,9 @@ mod tests {
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn validate_via_env_overlay(cfg_path: &str) -> anyhow::Result<()> {
-        let hoprd_args = hoprd::cli::CliArgs::try_parse_from([
-            "hoprd",
-            "--configurationFilePath",
-            cfg_path,
-        ])
-        .context("failed to parse args")?;
+        let hoprd_args =
+            hoprd::cli::CliArgs::try_parse_from(["hoprd", "--configurationFilePath", cfg_path])
+                .context("failed to parse args")?;
         let cfg = HoprdConfig::try_from(hoprd_args).context("failed to build config")?;
         cfg.validate().context("config validation failed")
     }

--- a/hoprd/src/bin/hoprd-cfg.rs
+++ b/hoprd/src/bin/hoprd-cfg.rs
@@ -51,7 +51,7 @@ use std::path::PathBuf;
 use anyhow::{Context, anyhow};
 use clap::Parser;
 use hoprd::config::HoprdConfig;
-use validator::Validate;
+use validator::Validate as _;
 
 #[derive(Parser, Default)]
 #[clap(author, version, about, long_about = None)]
@@ -79,11 +79,17 @@ fn main() -> anyhow::Result<()> {
             .into_string()
             .map_err(|_| anyhow!("file path not convertible"))?;
 
-        let yaml_configuration = std::fs::read_to_string(&cfg_path)
-            .with_context(|| format!("failed to read config file '{cfg_path}'"))?;
-
-        let cfg: HoprdConfig =
-            serde_saphyr::from_str(&yaml_configuration).context("failed to parse config YAML")?;
+        // Use hoprd's own CliArgs so that env-var overrides (e.g. HOPRD_PASSWORD)
+        // are applied exactly as hoprd would apply them at startup.  Without this,
+        // fields legitimately supplied via environment variables (the standard Docker
+        // Compose pattern) would always fail validation.
+        let hoprd_args = hoprd::cli::CliArgs::try_parse_from([
+            "hoprd",
+            "--configurationFilePath",
+            &cfg_path,
+        ])
+        .context("failed to parse args for validation")?;
+        let cfg = HoprdConfig::try_from(hoprd_args).context("failed to build config")?;
 
         cfg.validate().context("config validation failed")?;
     }

--- a/hoprd/src/bin/hoprd-cfg.rs
+++ b/hoprd/src/bin/hoprd-cfg.rs
@@ -28,13 +28,23 @@
 //!
 //! ## Validate an existing configuration YAML
 //!
+//! All validation errors found in the config are reported at once
+//! (one per line under `Caused by:`); the binary exits with code 1.
+//!
 //! ```shell
 //! ➜   hoprd-cfg -v /tmp/bad-config.yaml
-//! Error: ValidationError("The specified network 'anvil-localhost' is not listed as supported ([\"debug-staging\", \"dufour\", \"rotsee\"])")
+//! Error: config validation failed
+//!
+//! Caused by:
+//!     blokli_url: Validation error: url [{"value": String("not-a-valid-url")}]
+//!     identity.password: Validation error: No password could be found [{"value": String("")}]
 //!
 //! ➜   echo $?
 //! 1
 //! ```
+//!
+//! Note: YAML parsing errors (unknown fields, type mismatches) are
+//! reported by `serde` and stop at the first occurrence.
 
 use std::path::PathBuf;
 

--- a/hoprd/src/bin/hoprd-cfg.rs
+++ b/hoprd/src/bin/hoprd-cfg.rs
@@ -154,15 +154,21 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use super::validate_effective_config;
-    use hoprd::config::HoprdConfig;
+    use hoprd::config::{HoprdConfig, Identity};
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn config_file_without_password() -> anyhow::Result<NamedTempFile> {
-        // Serialize the default config (identity.password is "" by default)
-        // to get a valid YAML that fails validation only on the missing password.
-        let yaml = serde_saphyr::to_string(&HoprdConfig::default())
-            .context("failed to serialize default config")?;
+        // A config whose only validation gap is the missing password: an identity file is
+        // set (satisfying the identity-source requirement) while the password stays "".
+        let cfg = HoprdConfig {
+            identity: Identity {
+                file: "/tmp/hoprd-cfg-test-identity".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let yaml = serde_saphyr::to_string(&cfg).context("failed to serialize config")?;
         let mut file = NamedTempFile::new()?;
         file.write_all(yaml.as_bytes())?;
         Ok(file)

--- a/hoprd/src/bin/hoprd-cfg.rs
+++ b/hoprd/src/bin/hoprd-cfg.rs
@@ -28,6 +28,11 @@
 //!
 //! ## Validate an existing configuration YAML
 //!
+//! Validation reflects the *effective* configuration hoprd builds at startup:
+//! the YAML file with `HOPRD_*` environment variables (and CLI-equivalent
+//! overrides) layered on top. Values supplied via the environment are honored,
+//! so they are not falsely reported as missing or invalid.
+//!
 //! All validation errors found in the config are reported at once
 //! (one per line under `Caused by:`); the binary exits with code 1.
 //!

--- a/hoprd/src/bin/hoprd-cfg.rs
+++ b/hoprd/src/bin/hoprd-cfg.rs
@@ -50,6 +50,19 @@
 //!
 //! Note: YAML parsing errors (unknown fields, type mismatches) are
 //! reported by `serde` and stop at the first occurrence.
+//!
+//! ## Validate the effective config from hoprd arguments
+//!
+//! The container entrypoint uses `--validate-args` to validate the exact argument
+//! vector hoprd will receive (everything after `--`), so CLI-flag overrides are
+//! honored in addition to env vars and the YAML file:
+//!
+//! ```shell
+//! ➜   hoprd-cfg --validate-args -- --configurationFilePath /cfg.yaml --password s3cr3t
+//! ```
+//!
+//! A `--help`/`--version` request among the forwarded arguments is a no-op success,
+//! since hoprd itself handles those.
 
 use std::path::PathBuf;
 
@@ -62,11 +75,19 @@ use validator::Validate as _;
 #[clap(author, version, about, long_about = None)]
 struct CliArgs {
     /// Print the default YAML config for the hoprd
-    #[clap(short = 'd', long, conflicts_with = "validate")]
+    #[clap(short = 'd', long, conflicts_with_all = ["validate", "validate_args"])]
     default: bool,
     /// Validate the config at this path
-    #[clap(short, long, conflicts_with = "default")]
+    #[clap(short, long, conflicts_with_all = ["default", "validate_args"])]
     validate: Option<PathBuf>,
+    /// Validate the effective config built from the forwarded hoprd arguments
+    /// (everything after `--`), mirroring hoprd's startup. Honors env-var and
+    /// CLI-flag overrides, not just the YAML file.
+    #[clap(long = "validate-args", conflicts_with_all = ["default", "validate"])]
+    validate_args: bool,
+    /// hoprd arguments to validate; everything after `--`.
+    #[clap(last = true)]
+    forwarded_args: Vec<String>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -78,23 +99,49 @@ fn main() -> anyhow::Result<()> {
             serde_saphyr::to_string(&hoprd::config::HoprdConfig::default())
                 .context("failed to serialize default config")?
         );
+    } else if args.validate_args {
+        validate_effective_config(&args.forwarded_args)?;
     } else if let Some(cfg_path) = args.validate {
         let cfg_path = cfg_path
             .into_os_string()
             .into_string()
             .map_err(|_| anyhow!("file path not convertible"))?;
 
-        // Use hoprd's own CliArgs so that env-var overrides (e.g. HOPRD_PASSWORD)
-        // are applied exactly as hoprd would apply them at startup.  Without this,
-        // fields legitimately supplied via environment variables (the standard Docker
-        // Compose pattern) would always fail validation.
-        let hoprd_args =
-            hoprd::cli::CliArgs::try_parse_from(["hoprd", "--configurationFilePath", &cfg_path])
-                .context("failed to parse args for validation")?;
-        let cfg = HoprdConfig::try_from(hoprd_args).context("failed to build config")?;
-
-        cfg.validate().context("config validation failed")?;
+        validate_effective_config(&["--configurationFilePath".to_string(), cfg_path])?;
     }
+
+    Ok(())
+}
+
+/// Validates the effective hoprd configuration built from `args` (a hoprd CLI argument
+/// vector, without the leading program name).
+///
+/// This mirrors hoprd's own startup exactly: the YAML file with env-var and CLI-flag
+/// overrides layered on top, so values legitimately supplied via the environment or CLI
+/// are not falsely reported as missing or invalid. A `--help`/`--version` request is
+/// treated as success without validating, since hoprd itself renders those.
+fn validate_effective_config(args: &[String]) -> anyhow::Result<()> {
+    let argv = std::iter::once("hoprd".to_string()).chain(args.iter().cloned());
+
+    let hoprd_args = match hoprd::cli::CliArgs::try_parse_from(argv) {
+        Ok(parsed) => parsed,
+        Err(error)
+            if matches!(
+                error.kind(),
+                clap::error::ErrorKind::DisplayHelp
+                    | clap::error::ErrorKind::DisplayVersion
+                    | clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+            ) =>
+        {
+            return Ok(());
+        }
+        Err(error) => {
+            return Err(anyhow::Error::new(error).context("failed to parse args for validation"));
+        }
+    };
+
+    let cfg = HoprdConfig::try_from(hoprd_args).context("failed to build config")?;
+    cfg.validate().context("config validation failed")?;
 
     Ok(())
 }
@@ -104,21 +151,12 @@ mod tests {
     use std::io::Write;
 
     use anyhow::Context;
-    use clap::Parser as _;
     use tempfile::NamedTempFile;
-    use validator::Validate as _;
 
+    use super::validate_effective_config;
     use hoprd::config::HoprdConfig;
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn validate_via_env_overlay(cfg_path: &str) -> anyhow::Result<()> {
-        let hoprd_args =
-            hoprd::cli::CliArgs::try_parse_from(["hoprd", "--configurationFilePath", cfg_path])
-                .context("failed to parse args")?;
-        let cfg = HoprdConfig::try_from(hoprd_args).context("failed to build config")?;
-        cfg.validate().context("config validation failed")
-    }
 
     fn config_file_without_password() -> anyhow::Result<NamedTempFile> {
         // Serialize the default config (identity.password is "" by default)
@@ -131,6 +169,22 @@ mod tests {
     }
 
     #[test]
+    fn validate_passes_when_password_supplied_via_cli_flag() -> anyhow::Result<()> {
+        let file = config_file_without_password()?;
+        let path = file.path().to_str().unwrap().to_string();
+
+        // CLI flags are part of the forwarded argument vector, so they must be honored
+        // exactly as hoprd would at startup (no env mutation needed).
+        validate_effective_config(&[
+            "--configurationFilePath".to_string(),
+            path,
+            "--password".to_string(),
+            "a-securely-provided-password".to_string(),
+        ])
+        .context("expected validation to pass with --password supplied")
+    }
+
+    #[test]
     fn validate_passes_when_password_supplied_via_env() -> anyhow::Result<()> {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let file = config_file_without_password()?;
@@ -138,7 +192,8 @@ mod tests {
 
         // Safety: ENV_LOCK serializes all env-var access across tests in this module.
         unsafe { std::env::set_var("HOPRD_PASSWORD", "s3cr3tpassword") };
-        let result = validate_via_env_overlay(&path);
+        let result =
+            validate_effective_config(&["--configurationFilePath".to_string(), path.clone()]);
         unsafe { std::env::remove_var("HOPRD_PASSWORD") };
 
         result.context("expected validation to pass with HOPRD_PASSWORD set")
@@ -151,13 +206,23 @@ mod tests {
         let path = file.path().to_str().unwrap().to_string();
 
         unsafe { std::env::remove_var("HOPRD_PASSWORD") };
-        let result = validate_via_env_overlay(&path);
+        let result = validate_effective_config(&["--configurationFilePath".to_string(), path]);
 
         let err = result.expect_err("expected validation to fail without a password");
         assert!(
             err.to_string().contains("config validation failed"),
             "unexpected error: {err}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn help_and_version_requests_are_a_noop_success() -> anyhow::Result<()> {
+        // hoprd itself renders --help/--version; the validation gate must not block them.
+        validate_effective_config(&["--help".to_string()])
+            .context("--help should not fail validation")?;
+        validate_effective_config(&["--version".to_string()])
+            .context("--version should not fail validation")?;
         Ok(())
     }
 }

--- a/hoprd/src/bin/hoprd-cfg.rs
+++ b/hoprd/src/bin/hoprd-cfg.rs
@@ -96,3 +96,69 @@ fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use anyhow::Context;
+    use clap::Parser as _;
+    use tempfile::NamedTempFile;
+    use validator::Validate as _;
+
+    use hoprd::config::HoprdConfig;
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn validate_via_env_overlay(cfg_path: &str) -> anyhow::Result<()> {
+        let hoprd_args = hoprd::cli::CliArgs::try_parse_from([
+            "hoprd",
+            "--configurationFilePath",
+            cfg_path,
+        ])
+        .context("failed to parse args")?;
+        let cfg = HoprdConfig::try_from(hoprd_args).context("failed to build config")?;
+        cfg.validate().context("config validation failed")
+    }
+
+    fn config_file_without_password() -> anyhow::Result<NamedTempFile> {
+        // Serialize the default config (identity.password is "" by default)
+        // to get a valid YAML that fails validation only on the missing password.
+        let yaml = serde_saphyr::to_string(&HoprdConfig::default())
+            .context("failed to serialize default config")?;
+        let mut file = NamedTempFile::new()?;
+        file.write_all(yaml.as_bytes())?;
+        Ok(file)
+    }
+
+    #[test]
+    fn validate_passes_when_password_supplied_via_env() -> anyhow::Result<()> {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let file = config_file_without_password()?;
+        let path = file.path().to_str().unwrap().to_string();
+
+        // Safety: ENV_LOCK serializes all env-var access across tests in this module.
+        unsafe { std::env::set_var("HOPRD_PASSWORD", "s3cr3tpassword") };
+        let result = validate_via_env_overlay(&path);
+        unsafe { std::env::remove_var("HOPRD_PASSWORD") };
+
+        result.context("expected validation to pass with HOPRD_PASSWORD set")
+    }
+
+    #[test]
+    fn validate_fails_without_password_in_config_or_env() -> anyhow::Result<()> {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let file = config_file_without_password()?;
+        let path = file.path().to_str().unwrap().to_string();
+
+        unsafe { std::env::remove_var("HOPRD_PASSWORD") };
+        let result = validate_via_env_overlay(&path);
+
+        let err = result.expect_err("expected validation to fail without a password");
+        assert!(
+            err.to_string().contains("config validation failed"),
+            "unexpected error: {err}"
+        );
+        Ok(())
+    }
+}

--- a/hoprd/src/cli.rs
+++ b/hoprd/src/cli.rs
@@ -207,7 +207,8 @@ pub struct CliArgs {
     pub password: Option<String>,
 
     #[arg(
-        long,
+        long = "blokliUrl",
+        alias = "blokli-url",
         help = "URL for Blokli provider to be used for the node to connect to blockchain",
         env = "HOPRD_BLOKLI_URL",
         value_name = "BLOKLI_URL"

--- a/hoprd/src/cli.rs
+++ b/hoprd/src/cli.rs
@@ -73,6 +73,21 @@ fn detect_local_ipv4() -> anyhow::Result<IpAddr> {
         .ok_or_else(|| anyhow!("no non-loopback IPv4 address found for session listen host"))
 }
 
+fn resolve_session_listen_host(
+    host: HostConfig,
+    detect_local_ipv4: impl FnOnce() -> anyhow::Result<IpAddr>,
+) -> anyhow::Result<std::net::SocketAddr> {
+    match host.address {
+        HostType::IPv4(addr) => IpAddr::from_str(&addr)
+            .map(|ip| std::net::SocketAddr::new(ip, host.port))
+            .map_err(|_| anyhow!("invalid default session listen IP address")),
+        HostType::Domain(ref d) if d.eq_ignore_ascii_case(SESSION_LISTEN_HOST_AUTO) => {
+            detect_local_ipv4().map(|ip| std::net::SocketAddr::new(ip, host.port))
+        }
+        HostType::Domain(_) => Err(anyhow!("default session listen must be an IP")),
+    }
+}
+
 fn parse_api_token(mut s: &str) -> Result<String, String> {
     if s.len() < MINIMAL_API_TOKEN_LENGTH {
         return Err(format!(
@@ -322,15 +337,8 @@ impl TryFrom<CliArgs> for HoprdConfig {
         }
 
         if let Some(host) = value.default_session_listen_host {
-            cfg.session_ip_forwarding.default_entry_listen_host = match host.address {
-                HostType::IPv4(addr) => IpAddr::from_str(&addr)
-                    .map(|ip| std::net::SocketAddr::new(ip, host.port))
-                    .map_err(|_| anyhow!("invalid default session listen IP address")),
-                HostType::Domain(ref d) if d.eq_ignore_ascii_case(SESSION_LISTEN_HOST_AUTO) => {
-                    detect_local_ipv4().map(|ip| std::net::SocketAddr::new(ip, host.port))
-                }
-                HostType::Domain(_) => Err(anyhow!("default session listen must be an IP")),
-            }?;
+            cfg.session_ip_forwarding.default_entry_listen_host =
+                resolve_session_listen_host(host, detect_local_ipv4)?;
         }
         if value.enable_explicit_path_sessions {
             cfg.api.enable_explicit_path_sessions = true;
@@ -432,8 +440,11 @@ mod tests {
     #[test]
     fn auto_sentinel_resolves_to_non_loopback_ipv4_with_given_port() -> anyhow::Result<()> {
         let args = CliArgs::try_parse_from(["hoprd", "--defaultSessionListenHost", "auto:1234"])?;
-        let cfg = HoprdConfig::try_from(args)?;
-        let host: SocketAddr = cfg.session_ip_forwarding.default_entry_listen_host;
+        let host = resolve_session_listen_host(
+            args.default_session_listen_host
+                .expect("session listen host must be parsed"),
+            || Ok("10.20.30.40".parse()?),
+        )?;
 
         assert!(host.is_ipv4(), "expected an IPv4 address, got {host}");
         assert!(
@@ -448,12 +459,13 @@ mod tests {
     #[test]
     fn auto_sentinel_without_port_defaults_to_zero() -> anyhow::Result<()> {
         let args = CliArgs::try_parse_from(["hoprd", "--defaultSessionListenHost", "auto"])?;
-        let cfg = HoprdConfig::try_from(args)?;
+        let host = resolve_session_listen_host(
+            args.default_session_listen_host
+                .expect("session listen host must be parsed"),
+            || Ok("10.20.30.40".parse()?),
+        )?;
 
-        assert_eq!(
-            cfg.session_ip_forwarding.default_entry_listen_host.port(),
-            0
-        );
+        assert_eq!(host.port(), 0);
 
         Ok(())
     }

--- a/hoprd/src/cli.rs
+++ b/hoprd/src/cli.rs
@@ -15,6 +15,14 @@ pub const DEFAULT_API_PORT: u16 = 3001;
 
 pub const MINIMAL_API_TOKEN_LENGTH: usize = 8;
 
+/// Sentinel host for the session listen host that triggers local-IP auto-detection.
+///
+/// Used by container deployments that cannot know their routable IP ahead of time:
+/// `auto` (or `auto:<port>`) is resolved to the node's primary non-loopback IPv4 in
+/// [`HoprdConfig::try_from`]. Native deployments that leave the value unset keep the
+/// `127.0.0.1:0` default.
+pub const SESSION_LISTEN_HOST_AUTO: &str = "auto";
+
 fn parse_host(s: &str) -> Result<HostConfig, String> {
     let host = s.split_once(':').map_or(s, |(h, _)| h);
     if !(validator::ValidateIp::validate_ipv4(&host) || looks_like_domain(host)) {
@@ -24,6 +32,45 @@ fn parse_host(s: &str) -> Result<HostConfig, String> {
     }
 
     HostConfig::from_str(s)
+}
+
+/// Parses the session listen host, additionally accepting the [`SESSION_LISTEN_HOST_AUTO`]
+/// sentinel (`auto` or `auto:<port>`). The sentinel is carried as a `Domain` host and
+/// resolved to a concrete IP when the effective config is built.
+fn parse_session_listen_host(s: &str) -> Result<HostConfig, String> {
+    let (host, port) = match s.split_once(':') {
+        Some((h, p)) => (h, Some(p)),
+        None => (s, None),
+    };
+
+    if host.eq_ignore_ascii_case(SESSION_LISTEN_HOST_AUTO) {
+        let port = match port {
+            Some(p) => p
+                .parse::<u16>()
+                .map_err(|e| format!("invalid port '{p}' in session listen host: {e}"))?,
+            None => 0,
+        };
+        return Ok(HostConfig {
+            address: HostType::Domain(SESSION_LISTEN_HOST_AUTO.to_string()),
+            port,
+        });
+    }
+
+    parse_host(s)
+}
+
+/// Detects the node's primary non-loopback IPv4 address.
+///
+/// Mirrors the container entrypoint's historical `hostname -i` behavior: it returns the
+/// first non-loopback IPv4 reported by the host's network interfaces. Used to resolve the
+/// [`SESSION_LISTEN_HOST_AUTO`] sentinel into a concrete, advertisable address.
+fn detect_local_ipv4() -> anyhow::Result<IpAddr> {
+    if_addrs::get_if_addrs()
+        .context("failed to enumerate network interfaces")?
+        .into_iter()
+        .map(|iface| iface.ip())
+        .find(|ip| ip.is_ipv4() && !ip.is_loopback())
+        .ok_or_else(|| anyhow!("no non-loopback IPv4 address found for session listen host"))
 }
 
 fn parse_api_token(mut s: &str) -> Result<String, String> {
@@ -120,7 +167,7 @@ pub struct CliArgs {
         long = "defaultSessionListenHost",
         env = "HOPRD_DEFAULT_SESSION_LISTEN_HOST",
         help = "Default Session listening host for Session IP forwarding",
-        value_parser = ValueParser::new(parse_host),
+        value_parser = ValueParser::new(parse_session_listen_host),
     )]
     pub default_session_listen_host: Option<HostConfig>,
 
@@ -278,6 +325,9 @@ impl TryFrom<CliArgs> for HoprdConfig {
                 HostType::IPv4(addr) => IpAddr::from_str(&addr)
                     .map(|ip| std::net::SocketAddr::new(ip, host.port))
                     .map_err(|_| anyhow!("invalid default session listen IP address")),
+                HostType::Domain(ref d) if d.eq_ignore_ascii_case(SESSION_LISTEN_HOST_AUTO) => {
+                    detect_local_ipv4().map(|ip| std::net::SocketAddr::new(ip, host.port))
+                }
                 HostType::Domain(_) => Err(anyhow!("default session listen must be an IP")),
             }?;
         }
@@ -366,5 +416,70 @@ impl TryFrom<CliArgs> for HoprdConfig {
         }
 
         Ok(cfg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use clap::Parser as _;
+
+    use super::*;
+    use crate::config::HoprdConfig;
+
+    #[test]
+    fn auto_sentinel_resolves_to_non_loopback_ipv4_with_given_port() -> anyhow::Result<()> {
+        let args = CliArgs::try_parse_from(["hoprd", "--defaultSessionListenHost", "auto:1234"])?;
+        let cfg = HoprdConfig::try_from(args)?;
+        let host: SocketAddr = cfg.session_ip_forwarding.default_entry_listen_host;
+
+        assert!(host.is_ipv4(), "expected an IPv4 address, got {host}");
+        assert!(
+            !host.ip().is_loopback(),
+            "expected a non-loopback address, got {host}"
+        );
+        assert_eq!(host.port(), 1234);
+
+        Ok(())
+    }
+
+    #[test]
+    fn auto_sentinel_without_port_defaults_to_zero() -> anyhow::Result<()> {
+        let args = CliArgs::try_parse_from(["hoprd", "--defaultSessionListenHost", "auto"])?;
+        let cfg = HoprdConfig::try_from(args)?;
+
+        assert_eq!(
+            cfg.session_ip_forwarding.default_entry_listen_host.port(),
+            0
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn concrete_ipv4_listen_host_passes_through() -> anyhow::Result<()> {
+        let args =
+            CliArgs::try_parse_from(["hoprd", "--defaultSessionListenHost", "10.20.30.40:9091"])?;
+        let cfg = HoprdConfig::try_from(args)?;
+
+        assert_eq!(
+            cfg.session_ip_forwarding.default_entry_listen_host,
+            "10.20.30.40:9091".parse::<SocketAddr>()?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn non_auto_domain_listen_host_is_rejected() -> anyhow::Result<()> {
+        // A domain is accepted by CLI parsing but rejected when the effective config is built,
+        // because the session listen host must resolve to a concrete IP.
+        let args =
+            CliArgs::try_parse_from(["hoprd", "--defaultSessionListenHost", "example.com:9091"])?;
+
+        assert!(HoprdConfig::try_from(args).is_err());
+
+        Ok(())
     }
 }

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -353,7 +353,7 @@ mod tests {
     };
 
     use anyhow::Context;
-    use clap::{Args, Command, FromArgMatches};
+    use clap::{Args, Command, FromArgMatches, Parser};
     use hopr_lib::api::types::primitive::prelude::Address;
     use tempfile::NamedTempFile;
 
@@ -458,6 +458,72 @@ mod tests {
         let cfg = HoprdConfig::try_from(args)?;
 
         assert_eq!(cfg.blokli_url, pwnd.to_owned());
+
+        Ok(())
+    }
+
+    /// Writes `cfg` to a temporary YAML file and returns the file (kept alive by
+    /// the caller) together with its path.
+    fn write_cfg_file(cfg: &HoprdConfig) -> anyhow::Result<(NamedTempFile, String)> {
+        let mut config_file = NamedTempFile::new()?;
+        let yaml = serde_saphyr::to_string(cfg)?;
+        config_file.write_all(yaml.as_bytes())?;
+        let path = config_file
+            .path()
+            .to_str()
+            .context("file path should have a string representation")?
+            .to_string();
+        Ok((config_file, path))
+    }
+
+    #[test]
+    fn validation_should_fail_when_required_values_are_missing_from_the_file() -> anyhow::Result<()>
+    {
+        let mut cfg = example_cfg()?;
+        // Blank the password so the file on its own is genuinely invalid.
+        cfg.identity.password = String::new();
+
+        let (_file, cfg_path) = write_cfg_file(&cfg)?;
+
+        let cli_args = crate::cli::CliArgs::try_parse_from([
+            "hoprd",
+            "--configurationFilePath",
+            cfg_path.as_str(),
+        ])?;
+        let effective = HoprdConfig::try_from(cli_args)?;
+
+        assert!(
+            effective.validate().is_err(),
+            "config with an empty password must fail validation on its own"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn validation_should_pass_when_required_values_are_supplied_via_overrides() -> anyhow::Result<()>
+    {
+        let mut cfg = example_cfg()?;
+        // Same file as the negative test: invalid on its own due to the empty password.
+        cfg.identity.password = String::new();
+
+        let (_file, cfg_path) = write_cfg_file(&cfg)?;
+
+        // The password is supplied as a CLI/environment override (the exact code
+        // path that `HOPRD_PASSWORD` feeds into), so the effective config is valid.
+        let cli_args = crate::cli::CliArgs::try_parse_from([
+            "hoprd",
+            "--configurationFilePath",
+            cfg_path.as_str(),
+            "--password",
+            "a-securely-provided-password",
+        ])?;
+        let effective = HoprdConfig::try_from(cli_args)?;
+
+        assert!(
+            effective.validate().is_ok(),
+            "config must validate once the missing password is supplied via override"
+        );
 
         Ok(())
     }

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -56,7 +56,31 @@ fn validate_optional_private_key(s: &str) -> Result<(), ValidationError> {
     validate_private_key(s)
 }
 
+// Ensures the node has an identity source to load or create keys from: either a
+// non-empty identity file path or a private key. Without this, an empty file path
+// (the default) only surfaces as an opaque filesystem error at keypair creation.
+fn validate_identity_source(identity: &Identity) -> Result<(), ValidationError> {
+    let has_file = !identity.file.trim().is_empty();
+    let has_key = identity
+        .private_key
+        .as_ref()
+        .is_some_and(|k| !k.trim().is_empty());
+
+    if has_file || has_key {
+        return Ok(());
+    }
+
+    let mut error = ValidationError::new("identity_source_missing");
+    error.message = Some(
+        "no identity source configured: provide an identity file via --identity \
+         (HOPRD_IDENTITY) or a private key via --privateKey (HOPRD_PRIVATE_KEY)"
+            .into(),
+    );
+    Err(error)
+}
+
 #[derive(Default, Serialize, Deserialize, Validate, Clone, PartialEq)]
+#[validate(schema(function = "validate_identity_source", skip_on_field_errors = false))]
 #[serde(deny_unknown_fields)]
 pub struct Identity {
     #[validate(custom(function = "validate_file_path"))]
@@ -524,6 +548,48 @@ mod tests {
             effective.validate().is_ok(),
             "config must validate once the missing password is supplied via override"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn validation_fails_when_no_identity_source() -> anyhow::Result<()> {
+        let mut cfg = example_cfg()?;
+        cfg.identity.file = String::new();
+        cfg.identity.private_key = None;
+
+        let err = cfg
+            .validate()
+            .expect_err("a config without any identity source must fail validation");
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.contains("identity_source_missing"),
+            "unexpected error: {rendered}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn validation_passes_with_private_key_and_no_file() -> anyhow::Result<()> {
+        let mut cfg = example_cfg()?;
+        cfg.identity.file = String::new();
+        // A valid 128-hex private key satisfies both the source requirement and the key format.
+        cfg.identity.private_key = Some(format!("0x{}", "a".repeat(128)));
+
+        cfg.validate()
+            .context("a private key alone should satisfy the identity source requirement")?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn validation_passes_with_identity_file_and_no_key() -> anyhow::Result<()> {
+        // `example_cfg` sets `identity.file` and leaves `private_key` unset.
+        let cfg = example_cfg()?;
+
+        cfg.validate()
+            .context("an identity file alone should satisfy the identity source requirement")?;
 
         Ok(())
     }

--- a/hoprd/src/main.rs
+++ b/hoprd/src/main.rs
@@ -35,6 +35,14 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
+    // Ensure the configured temporary directory exists before any component relies on it.
+    // Container images set TMPDIR to a path that may not exist yet on first start.
+    if let Ok(tmp_dir) = std::env::var("TMPDIR")
+        && let Err(error) = std::fs::create_dir_all(&tmp_dir)
+    {
+        tracing::warn!(%error, tmp_dir, "failed to create TMPDIR");
+    }
+
     let num_cpu_threads = std::env::var("HOPRD_NUM_CPU_THREADS").ok().and_then(|v| {
         usize::from_str(&v)
             .map_err(anyhow::Error::from)

--- a/hoprd/src/main.rs
+++ b/hoprd/src/main.rs
@@ -90,7 +90,15 @@ fn main() -> ExitCode {
     let hopr_keys: HoprKeys = match maybe_keys.try_into() {
         Ok(hopr_keys) => hopr_keys,
         Err(error) => {
-            tracing::error!(%error, "hoprd exited with an error");
+            // The underlying KeyPairError does not carry the path, so name the source here.
+            match &cfg.identity.private_key {
+                Some(_) => {
+                    tracing::error!(%error, "failed to load identity keys from the provided private key")
+                }
+                None => {
+                    tracing::error!(%error, identity_file = %cfg.identity.file, "failed to load or create identity keys")
+                }
+            }
             return ExitCode::FAILURE;
         }
     };

--- a/profiling/jeprof-vm-usage.md
+++ b/profiling/jeprof-vm-usage.md
@@ -125,7 +125,7 @@ _RJEM_MALLOC_CONF='prof:true,prof_active:true,prof_final:true,prof_prefix:/tmp/j
   --data /tmp/hoprd \
   --identity /tmp/hoprd/identity \
   --apiHost 127.0.0.1 \
-  --blokli-url https://blokli.rotsee.hoprnet.link
+  --blokliUrl https://blokli.rotsee.hoprnet.link
 ```
 
 ### Tuning `_RJEM_MALLOC_CONF`

--- a/profiling/memory-profiling.md
+++ b/profiling/memory-profiling.md
@@ -53,7 +53,7 @@ nix build .#binary-hoprd-profile-aarch64-linux   # ARM64
      -e "_RJEM_MALLOC_CONF=prof:true,prof_active:true,prof_final:true,prof_prefix:/app/.tmp/jeprof,lg_prof_sample:19,lg_prof_interval:26" \
      -e "HOPRD_PASSWORD=my-password" \
      hoprd:latest \
-     bash -c "mkdir -p /tmp/hoprd /app/.tmp && exec hoprd --data /tmp/hoprd --identity /tmp/hoprd/identity --apiHost 0.0.0.0 --blokli-url https://your-blokli-url"
+     bash -c "mkdir -p /tmp/hoprd /app/.tmp && exec hoprd --data /tmp/hoprd --identity /tmp/hoprd/identity --apiHost 0.0.0.0 --blokliUrl https://your-blokli-url"
    ```
 
    > **Note:** The `_RJEM_` prefix is required because `tikv-jemallocator` renames jemalloc symbols. The standard `MALLOC_CONF` variable will not work.


### PR DESCRIPTION
  Closes hoprnet/hoprnet#8126 by validating the effective hoprd configuration before Docker startup.

  ## Changes

  - Added a shared Docker entrypoint that runs hoprd-cfg --validate-args -- "$@" before launching hoprd.
  - Added hoprd-cfg --validate-args to validate the same config hoprd will use: YAML + env-var overlays + CLI overrides.
  - Made --validate <path> reuse the same effective-config validation path, so env-provided values like HOPRD_PASSWORD are honored.
  - Added an entrypoint escape hatch for commands like docker run <image> bash.
  - Moved Docker startup defaults into image env, including TMPDIR, cert paths, and HOPRD_DEFAULT_SESSION_LISTEN_HOST=auto:0.
  - Added auto / auto:<port> support for --defaultSessionListenHost.
  - Added identity-source validation for missing identity file/private key.
  - Added tini as PID 1 for production Docker images.
  - Added ShellCheck coverage for the Docker entrypoint.

  ## Behavior

  - Valid config: validation passes and hoprd starts.
  - Invalid config: validation error is printed and the container exits with the hoprd-cfg status.
  - Env/CLI overrides are included in validation.
  - --help and --version pass through for hoprd to render.
  - Direct debug commands skip validation.

  No REST API or systemd changes.