### PR TITLE
feat: update hopr-lib to fix lingering issues related to CPU load

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "force-frame-pointers=yes"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "force-frame-pointers=yes"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "force-frame-pointers=yes"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,19 @@
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "force-frame-pointers=yes"]
+rustflags = [
+  "-C",
+  "force-frame-pointers=yes",
+  "-C",
+  "debuginfo=2",
+  "-C",
+  "inline-threshold=0",
+]
 
 [target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "force-frame-pointers=yes"]
+rustflags = [
+  "-C",
+  "force-frame-pointers=yes",
+  "-C",
+  "debuginfo=2",
+  "-C",
+  "inline-threshold=0",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4566,8 +4566,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-reference"
-version = "4.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+version = "4.2.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4637,8 +4637,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+version = "0.28.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.1.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=9a6e40198332cb40c0a4326681dbae66e619ed44#9a6e40198332cb40c0a4326681dbae66e619ed44"
+source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8406,7 +8406,7 @@ checksum = "f83ad47c2f14654528a89495f8d0dbc64173176f8512c7c72386cbe81009f661"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "nohash-hasher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd"
-version = "4.0.2-rc.3"
+version = "4.0.2-rc.4"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4637,8 +4637,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+version = "0.29.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.1.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=34bd0a89e42bfa39fafc9de57a93b6b974076647#34bd0a89e42bfa39fafc9de57a93b6b974076647"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4637,8 +4637,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+version = "0.29.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.1.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4638,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.29.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4680,8 +4680,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-mixer"
-version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+version = "0.4.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.1.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=308773aa626ce2dddd07aa73daa00aa0dc2ae1c6#308773aa626ce2dddd07aa73daa00aa0dc2ae1c6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,12 +4359,13 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+version = "0.20.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "ahash",
  "anyhow",
  "async-broadcast",
+ "async-lock",
  "async-trait",
  "atomic_enum",
  "blokli-client",
@@ -4389,7 +4390,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4460,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4477,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4490,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4521,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4552,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4567,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4590,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4616,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4637,8 +4638,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+version = "0.29.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4681,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4696,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4716,8 +4717,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+version = "0.6.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4775,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4842,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4872,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.1.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=bfa1e9f206a585fb0ed5765265e25a73132ac0b2#bfa1e9f206a585fb0ed5765265e25a73132ac0b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=405184836679cc71753a446f40c1c273e47f0e7a#405184836679cc71753a446f40c1c273e47f0e7a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4637,8 +4637,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+version = "0.29.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.1.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ef24912a308a899159d17c3c86a542085c3f2f5e#ef24912a308a899159d17c3c86a542085c3f2f5e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a066b8b68e6822bef328168e7174f9f4afcacab6#a066b8b68e6822bef328168e7174f9f4afcacab6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,5 +166,12 @@ strip = false
 lto = "thin"
 codegen-units = 16
 
+[profile.flamegraph]
+inherits = "release"
+debug = true
+strip = false
+lto = false
+codegen-units = 16
+
 [workspace.metadata.cargo-shear]
 ignored = ["oas3", "humantime-serde", "hopr-api", "hopr-utils"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6" }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2" }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647" }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e" }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "bfa1e9f206a585fb0ed5765265e25a73132ac0b2" }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "405184836679cc71753a446f40c1c273e47f0e7a" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "405184836679cc71753a446f40c1c273e47f0e7a" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "405184836679cc71753a446f40c1c273e47f0e7a", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "405184836679cc71753a446f40c1c273e47f0e7a", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "405184836679cc71753a446f40c1c273e47f0e7a", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "405184836679cc71753a446f40c1c273e47f0e7a", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "405184836679cc71753a446f40c1c273e47f0e7a", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "405184836679cc71753a446f40c1c273e47f0e7a", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "405184836679cc71753a446f40c1c273e47f0e7a" }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,8 @@ vergen-gix = { version = "9.1.0", features = ["build"] }
 [profile.dev]
 panic = "abort"
 opt-level = 1
+strip = false
+debug = true
 
 [profile.candidate]
 inherits = "release"
@@ -142,7 +144,10 @@ opt-level = 1
 codegen-units = 1
 lto = "fat"
 panic = "abort"
-strip = true
+# Temporary production-debugging defaults:
+# keep symbols in release artifacts for postmortem analysis.
+strip = false
+debug = 2
 opt-level = 3
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "9a6e40198332cb40c0a4326681dbae66e619ed44" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "9a6e40198332cb40c0a4326681dbae66e619ed44" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "9a6e40198332cb40c0a4326681dbae66e619ed44", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "9a6e40198332cb40c0a4326681dbae66e619ed44", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "9a6e40198332cb40c0a4326681dbae66e619ed44", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "9a6e40198332cb40c0a4326681dbae66e619ed44", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "9a6e40198332cb40c0a4326681dbae66e619ed44", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "9a6e40198332cb40c0a4326681dbae66e619ed44", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "9a6e40198332cb40c0a4326681dbae66e619ed44" }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "34bd0a89e42bfa39fafc9de57a93b6b974076647" }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.9.0" }
@@ -151,8 +151,6 @@ split-debuginfo = "off"
 strip = false
 
 [profile.dev.package]
-insta.opt-level = 3
-similar.opt-level = 3
 
 # memory profiling profile — inherits release optimizations but preserves debug symbols
 # for jeprof symbol resolution

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6" }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "308773aa626ce2dddd07aa73daa00aa0dc2ae1c6" }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "ef24912a308a899159d17c3c86a542085c3f2f5e" }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a066b8b68e6822bef328168e7174f9f4afcacab6" }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,8 @@ split-debuginfo = "off"
 strip = false
 
 [profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3
 
 # memory profiling profile — inherits release optimizations but preserves debug symbols
 # for jeprof symbol resolution

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,10 +144,8 @@ opt-level = 1
 codegen-units = 1
 lto = "fat"
 panic = "abort"
-# Temporary production-debugging defaults:
-# keep symbols in release artifacts for postmortem analysis.
 strip = false
-debug = 2
+debug = "line-tables-only"
 opt-level = 3
 
 [profile.bench]

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -104,7 +104,7 @@ The supported profiles are:
 - `metrics`: utilites exporting system, docker and node metrics
 - `metrics-push`: a utility cronjob to publish metrics to an external prometheus push gateway
 - `metrics-vis`: visualization tools for the metrics (containing the prometheus and grafana setup with default dashboards)
-- `tracing`: Enable Jaeger OTLP ingestion for hoprd telemetry. Set `HOPRD_USE_OPENTELEMETRY=true` and configure `HOPRD_OTEL_SIGNALS` (for example `traces` or `traces,logs,metrics`). Configure `HOPRD_METRIC_EXPORT_INTERVAL` as `default_ms,prefix=ms` (for example `15000,hopr_session=1000`).
+- `tracing`: Enable Jaeger OTLP ingestion for hoprd telemetry. Set `HOPRD_OTLP_ENDPOINT` to the collector address — OpenTelemetry is enabled automatically when an endpoint is configured. Optionally set `HOPRD_OTEL_SIGNALS` (for example `traces` or `traces,logs,metrics`) and `HOPRD_METRIC_EXPORT_INTERVAL` as `default_ms,prefix=ms` (for example `15000,hopr_session=1000`). Use `HOPRD_USE_OPENTELEMETRY=false` to suppress telemetry even when an endpoint is set.
 
 Profiles should be specified as a list of `,` separated values in the `COMPOSE_PROFILES` environment variable.
 

--- a/flake.nix
+++ b/flake.nix
@@ -198,13 +198,20 @@
             binary-hoprd-localcluster = rust-builder-local.callPackage nixLib.mkRustPackage localclusterBuildArgs;
             binary-hoprd-x86_64-linux = rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage projectBuildArgs;
             binary-hoprd-localcluster-x86_64-linux = rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage localclusterBuildArgs;
-            binary-hoprd-dev-x86_64-linux = rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage (
-              projectBuildArgs
-              // {
-                CARGO_PROFILE = "dev";
-                cargoExtraArgs = "-p hoprd -p hoprd-api -F capture";
-              }
-            );
+            binary-hoprd-dev-x86_64-linux = (
+              rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage (
+                projectBuildArgs
+                // {
+                  CARGO_PROFILE = "dev";
+                  cargoExtraArgs = "-p hoprd -p hoprd-api -F capture";
+                }
+              )
+            ).overrideAttrs
+              (_: {
+                CARGO_PROFILE_DEV_STRIP = "none";
+                dontStrip = true;
+                separateDebugInfo = false;
+              });
             binary-hoprd-aarch64-linux = rust-builder-aarch64-linux.callPackage nixLib.mkRustPackage projectBuildArgs;
             binary-hoprd-x86_64-darwin = rust-builder-x86_64-darwin.callPackage nixLib.mkRustPackage projectBuildArgs;
             binary-hoprd-aarch64-darwin = rust-builder-aarch64-darwin.callPackage nixLib.mkRustPackage projectBuildArgs;

--- a/flake.nix
+++ b/flake.nix
@@ -198,20 +198,19 @@
             binary-hoprd-localcluster = rust-builder-local.callPackage nixLib.mkRustPackage localclusterBuildArgs;
             binary-hoprd-x86_64-linux = rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage projectBuildArgs;
             binary-hoprd-localcluster-x86_64-linux = rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage localclusterBuildArgs;
-            binary-hoprd-dev-x86_64-linux = (
-              rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage (
+            binary-hoprd-dev-x86_64-linux =
+              (rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage (
                 projectBuildArgs
                 // {
                   CARGO_PROFILE = "dev";
                   cargoExtraArgs = "-p hoprd -p hoprd-api -F capture";
                 }
-              )
-            ).overrideAttrs
-              (_: {
-                CARGO_PROFILE_DEV_STRIP = "none";
-                dontStrip = true;
-                separateDebugInfo = false;
-              });
+              )).overrideAttrs
+                (_: {
+                  CARGO_PROFILE_DEV_STRIP = "none";
+                  dontStrip = true;
+                  separateDebugInfo = false;
+                });
             binary-hoprd-aarch64-linux = rust-builder-aarch64-linux.callPackage nixLib.mkRustPackage projectBuildArgs;
             binary-hoprd-x86_64-darwin = rust-builder-x86_64-darwin.callPackage nixLib.mkRustPackage projectBuildArgs;
             binary-hoprd-aarch64-darwin = rust-builder-aarch64-darwin.callPackage nixLib.mkRustPackage projectBuildArgs;

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd"
-version = "4.0.2-rc.3"
+version = "4.0.2-rc.4"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/hoprd/src/telemetry.rs
+++ b/hoprd/src/telemetry.rs
@@ -117,13 +117,20 @@ impl NodeTelemetryIdentity {
 
 impl OtlpConfig {
     fn from_env() -> Self {
-        let enabled = matches!(
-            std::env::var("HOPRD_USE_OPENTELEMETRY")
+        let enabled = match std::env::var("HOPRD_USE_OPENTELEMETRY")
+            .ok()
+            .map(|v| v.trim().to_ascii_lowercase())
+            .as_deref()
+        {
+            Some("1" | "true" | "yes" | "on") => true,
+            Some("0" | "false" | "no" | "off") => false,
+            // Unset, empty, or unrecognised: auto-enable when an OTLP endpoint is present.
+            // `apply_hoprd_otlp_endpoint_override` has already normalised
+            // `HOPRD_OTLP_ENDPOINT` into `OTEL_EXPORTER_OTLP_ENDPOINT` before this runs.
+            _ => std::env::var(LEGACY_OTLP_ENDPOINT_ENV_KEY)
                 .ok()
-                .map(|v| v.trim().to_ascii_lowercase())
-                .as_deref(),
-            Some("1" | "true" | "yes" | "on")
-        );
+                .is_some_and(|v| !v.trim().is_empty()),
+        };
         let transport = OtlpTransport::from_env();
         let mut signals = flagset::FlagSet::empty();
 

--- a/hoprd/src/telemetry.rs
+++ b/hoprd/src/telemetry.rs
@@ -117,20 +117,39 @@ impl NodeTelemetryIdentity {
 
 impl OtlpConfig {
     fn from_env() -> Self {
-        let enabled = match std::env::var("HOPRD_USE_OPENTELEMETRY")
-            .ok()
-            .map(|v| v.trim().to_ascii_lowercase())
+        let use_var_raw = std::env::var("HOPRD_USE_OPENTELEMETRY").ok();
+        let hoprd_endpoint = std::env::var(HOPRD_OTLP_ENDPOINT_ENV_KEY).ok();
+        let legacy_endpoint = std::env::var(LEGACY_OTLP_ENDPOINT_ENV_KEY).ok();
+
+        let use_var_normalised = use_var_raw
             .as_deref()
-        {
-            Some("1" | "true" | "yes" | "on") => true,
-            Some("0" | "false" | "no" | "off") => false,
-            // Unset, empty, or unrecognised: auto-enable when an OTLP endpoint is present.
-            // `apply_hoprd_otlp_endpoint_override` has already normalised
-            // `HOPRD_OTLP_ENDPOINT` into `OTEL_EXPORTER_OTLP_ENDPOINT` before this runs.
-            _ => std::env::var(LEGACY_OTLP_ENDPOINT_ENV_KEY)
-                .ok()
-                .is_some_and(|v| !v.trim().is_empty()),
+            .map(|v| v.trim().to_ascii_lowercase());
+
+        // Auto-enable only on the HOPRD-prefixed var to avoid action-at-a-distance
+        // from ambient OTEL_EXPORTER_OTLP_ENDPOINT exports (e.g. jaeger-cli or
+        // sibling OTel SDK tools sharing the environment).
+        let (enabled, reason): (bool, &'static str) = match use_var_normalised.as_deref() {
+            Some("1" | "true" | "yes" | "on") => (true, "HOPRD_USE_OPENTELEMETRY=true"),
+            Some("0" | "false" | "no" | "off") => (false, "HOPRD_USE_OPENTELEMETRY=false"),
+            _ if hoprd_endpoint
+                .as_deref()
+                .is_some_and(|v| !v.trim().is_empty()) =>
+            {
+                (true, "HOPRD_OTLP_ENDPOINT set, auto-enabled")
+            }
+            _ => (false, "no HOPRD OTLP env vars set"),
         };
+
+        tracing::info!(
+            target: "hoprd::telemetry::gate",
+            enabled,
+            reason,
+            use_opentelemetry_raw = ?use_var_raw,
+            hoprd_otlp_endpoint = ?hoprd_endpoint,
+            otel_exporter_otlp_endpoint = ?legacy_endpoint,
+            "OpenTelemetry gate decision"
+        );
+
         let transport = OtlpTransport::from_env();
         let mut signals = flagset::FlagSet::empty();
 

--- a/hoprd/src/telemetry.rs
+++ b/hoprd/src/telemetry.rs
@@ -164,8 +164,8 @@ impl OtlpConfig {
             enabled,
             reason,
             use_opentelemetry_raw = ?use_var_raw,
-            hoprd_otlp_endpoint = ?hoprd_endpoint,
-            otel_exporter_otlp_endpoint = ?legacy_endpoint,
+            hoprd_otlp_endpoint_set = hoprd_endpoint.is_some(),
+            otel_exporter_otlp_endpoint_set = legacy_endpoint.is_some(),
             "OpenTelemetry gate decision"
         );
 

--- a/localcluster/src/client_helper.rs
+++ b/localcluster/src/client_helper.rs
@@ -221,10 +221,6 @@ pub async fn start_nodes(config: &NodeStartConfig<'_>) -> Result<Vec<NodeProcess
             .arg("--password")
             .arg(config.identity_password)
             .env(
-                "HOPRD_USE_OPENTELEMETRY",
-                std::env::var("HOPRD_USE_OPENTELEMETRY").unwrap_or_else(|_| "true".to_string()),
-            )
-            .env(
                 "HOPRD_OTEL_SIGNALS",
                 std::env::var("HOPRD_OTEL_SIGNALS").unwrap_or_else(|_| "metrics".to_string()),
             )


### PR DESCRIPTION
## Summary

- Updates all `hopr-*` dependencies to `rev = eb21c1354c20d3cd6c891abfedab33d74b5003d1` (first commit on default branch with both CPU fixes and `explicit-path` feature in `hopr-utils-session`)
- Defaults `HOPRD_USE_OPENTELEMETRY` to `false`; auto-enables only when `HOPRD_OTLP_ENDPOINT` is explicitly set
- Drops auto-enable on ambient `OTEL_EXPORTER_OTLP_ENDPOINT` to prevent action-at-a-distance from sibling OTel SDK tools
- Logs the gate decision (enabled, reason, set/unset status for each env var) at `INFO` on startup so OTel state is self-diagnosing from logs — endpoint URLs are not logged to avoid credential leakage
- Merged main (2026-05-26) to resolve conflicts; hopr-lib rev updated to eb21c135 to satisfy explicit-path requirement from #20

> Review feedback (profile reverts, counter_flush_interval fix) addressed in stacked PR #42.