### PR TITLE
chore(deps): bump hoprnet rev to fix msg-ingress receiver-gone crash

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -157,7 +157,7 @@ jobs:
   build-docker:
     name: Docker
     needs: build-binaries
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@30f77f2fd7306bd460e19fe088b4dff4493d5f3d # temporary: pin to registries.conf fix; revert to @build-docker-v2 after tag move
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -157,7 +157,7 @@ jobs:
   build-docker:
     name: Docker
     needs: build-binaries
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@30f77f2fd7306bd460e19fe088b4dff4493d5f3d # temporary: pin to registries.conf fix; revert to @build-docker-v2 after tag move
     permissions:
       contents: read
       pull-requests: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -836,7 +836,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2764,7 +2764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4428,8 +4428,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+version = "4.0.3-rc.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4588,8 +4588,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.19.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+version = "0.19.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4635,8 +4635,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+version = "0.28.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4693,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4771,7 +4771,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4838,7 +4838,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4868,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=518cf91d15bb41d44e3c41419bc3daf701e9129a#518cf91d15bb41d44e3c41419bc3daf701e9129a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=29f2d12ef868570571af869cc591a197ec84b41b#29f2d12ef868570571af869cc591a197ec84b41b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4894,7 +4894,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd"
-version = "4.0.2-rc.4"
+version = "4.0.3-rc.4"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -5195,7 +5195,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5577,7 +5577,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6576,7 +6576,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7496,7 +7496,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7533,7 +7533,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8082,7 +8082,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8810,7 +8810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9001,7 +9001,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10064,7 +10064,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "518cf91d15bb41d44e3c41419bc3daf701e9129a" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "518cf91d15bb41d44e3c41419bc3daf701e9129a" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "518cf91d15bb41d44e3c41419bc3daf701e9129a", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "518cf91d15bb41d44e3c41419bc3daf701e9129a", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "518cf91d15bb41d44e3c41419bc3daf701e9129a", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "518cf91d15bb41d44e3c41419bc3daf701e9129a", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "518cf91d15bb41d44e3c41419bc3daf701e9129a", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "518cf91d15bb41d44e3c41419bc3daf701e9129a", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "518cf91d15bb41d44e3c41419bc3daf701e9129a", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "29f2d12ef868570571af869cc591a197ec84b41b", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd"
-version = "4.0.2-rc.4"
+version = "4.0.3-rc.4"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/localcluster/src/blokli_helper.rs
+++ b/localcluster/src/blokli_helper.rs
@@ -55,14 +55,14 @@ impl ChainHandle {
         let name = CONTAINER_NAME;
 
         // Apple `container` uses --arch amd64; Docker/Podman use --platform linux/amd64.
-        let basename = std::path::Path::new(runtime)
+        let runtime_name = std::path::Path::new(runtime)
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or(runtime);
 
         let mut cmd = Command::new(runtime);
         cmd.arg("run").arg("--rm").arg("--name").arg(name);
-        if basename == "container" {
+        if runtime_name == "container" {
             cmd.arg("--arch").arg("amd64");
         } else {
             cmd.arg("--platform").arg("linux/amd64");


### PR DESCRIPTION
## Summary

Bumps all hoprnet crate revs to `29f2d12ef868570571af869cc591a197ec84b41b` which includes the `fix(transport): drain on_incoming_data_rx to prevent SessionsManagement(0) crash` fix (hoprnet PR #8148).

The fix prevents the entire HOPR packet ingress pipeline from collapsing when `on_incoming_data_rx` is dropped — the root cause of persistent `receiver is gone` errors and silent session INIT drops that have been breaking exit-node connectivity.

Depends on: https://github.com/hoprnet/hoprnet/pull/8148