### PR TITLE
feat(hoprd): add typed mixer config to UserHoprNetworkConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4840,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4840,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c0b1a961fa0b2dee44b49c22ad8a2329d050448d#c0b1a961fa0b2dee44b49c22ad8a2329d050448d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4678,13 +4678,15 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "futures",
  "futures-timer",
  "hopr-types",
+ "humantime-serde",
  "lazy_static",
  "parking_lot",
+ "serde",
  "smart-default",
  "thiserror 2.0.18",
  "tracing",
@@ -4693,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4713,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4738,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4771,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4838,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4868,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=e143b5c7014f85056ee300e0811b4ca211d3c524#e143b5c7014f85056ee300e0811b4ca211d3c524"
+source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4840,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=ee7633caec6ab61e233091c49c42d7252f0fb01d#ee7633caec6ab61e233091c49c42d7252f0fb01d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=373a6615863731493478b20cdc96b13c4a7eeae5#373a6615863731493478b20cdc96b13c4a7eeae5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "373a6615863731493478b20cdc96b13c4a7eeae5", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "e143b5c7014f85056ee300e0811b4ca211d3c524", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "ee7633caec6ab61e233091c49c42d7252f0fb01d", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "c0b1a961fa0b2dee44b49c22ad8a2329d050448d", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use hopr_lib::{
     api::types::{internal::tickets::WinningProbability, primitive::prelude::HoprBalance},
     config::{
-        HoprLibConfig, HoprPacketPipelineConfig, HostConfig, HostType, ProbeConfig, SafeModule,
-        SessionGlobalConfig, TransportConfig,
+        HoprLibConfig, HoprPacketPipelineConfig, HostConfig, HostType, MixerConfig, ProbeConfig,
+        SafeModule, SessionGlobalConfig, TransportConfig,
     },
     exports::transport::{HoprProtocolConfig, TagAllocatorConfig, config::HoprCodecConfig},
 };
@@ -199,6 +199,14 @@ pub struct UserHoprNetworkConfig {
     /// and will default to that value whenever it is lower.
     #[serde(default)]
     pub min_incoming_ticket_price: Option<HoprBalance>,
+    /// Packet mixer configuration.
+    ///
+    /// Controls the minimum delay, delay spread, and buffer capacity of the HOPR packet mixer.
+    /// Defaults to `MixerConfig::default()` (0 ms min, 20 ms spread, 20 000 capacity).
+    /// Use [`hopr_lib::config::build_mixer_cfg_from_env`] to load from `HOPR_INTERNAL_MIXER_*`
+    /// environment variables instead.
+    #[serde(default)]
+    pub mixer: MixerConfig,
 }
 
 /// Subset of the [`HoprLibConfig`] that is tuned to be user-facing and more user-friendly.
@@ -279,6 +287,7 @@ impl From<UserHoprLibConfig> for HoprLibConfig {
                 },
                 path_planner: Default::default(),
                 counter_flush_interval: HoprProtocolConfig::default().counter_flush_interval,
+                mixer: value.network.mixer,
             },
             ..Default::default()
         }
@@ -590,6 +599,30 @@ mod tests {
 
         cfg.validate()
             .context("an identity file alone should satisfy the identity source requirement")?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_mixer_section_round_trips() -> anyhow::Result<()> {
+        use std::time::Duration;
+
+        let mut cfg = example_cfg()?;
+        cfg.hopr.network.mixer = hopr_lib::config::MixerConfig {
+            min_delay: Duration::from_millis(0),
+            delay_range: Duration::from_millis(15),
+            capacity: 5_000,
+            ..Default::default()
+        };
+        let yaml = serde_saphyr::to_string(&cfg)?;
+        let from_yaml: HoprdConfig = serde_saphyr::from_str(&yaml)?;
+        assert_eq!(cfg, from_yaml);
+        assert!(!yaml.contains("metric_delay_window"));
+        let lib_cfg: HoprLibConfig = cfg.hopr.into();
+        assert_eq!(
+            lib_cfg.protocol.mixer.delay_range,
+            Duration::from_millis(15)
+        );
 
         Ok(())
     }

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -159,6 +159,28 @@ fn default_outgoing_ticket_winning_prob() -> Option<f64> {
         .map(|p| p.as_f64())
 }
 
+fn build_mixer_cfg_from_env() -> MixerConfig {
+    let defaults = MixerConfig::default();
+    MixerConfig {
+        min_delay: std::env::var("HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .map(Duration::from_millis)
+            .unwrap_or(defaults.min_delay),
+        delay_range: std::env::var("HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .map(Duration::from_millis)
+            .unwrap_or(defaults.delay_range),
+        capacity: std::env::var("HOPR_INTERNAL_MIXER_CAPACITY")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|&c| c > 0)
+            .unwrap_or(defaults.capacity),
+        ..defaults
+    }
+}
+
 /// Subset of various selected HOPR library network-related configuration options.
 #[derive(Debug, Clone, PartialEq, smart_default::SmartDefault, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -202,10 +224,9 @@ pub struct UserHoprNetworkConfig {
     /// Packet mixer configuration.
     ///
     /// Controls the minimum delay, delay spread, and buffer capacity of the HOPR packet mixer.
-    /// Defaults to `MixerConfig::default()` (0 ms min, 20 ms spread, 20 000 capacity).
-    /// Use [`hopr_lib::config::build_mixer_cfg_from_env`] to load from `HOPR_INTERNAL_MIXER_*`
-    /// environment variables instead.
-    #[serde(default)]
+    /// When omitted from the config file, falls back to `HOPR_INTERNAL_MIXER_*` env vars,
+    /// then to compiled-in defaults (0 ms min, 20 ms spread, 20 000 capacity).
+    #[serde(default = "build_mixer_cfg_from_env")]
     pub mixer: MixerConfig,
 }
 

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -226,6 +226,7 @@ pub struct UserHoprNetworkConfig {
     /// Controls the minimum delay, delay spread, and buffer capacity of the HOPR packet mixer.
     /// When omitted from the config file, falls back to `HOPR_INTERNAL_MIXER_*` env vars,
     /// then to compiled-in defaults (0 ms min, 20 ms spread, 20 000 capacity).
+    #[default(build_mixer_cfg_from_env())]
     #[serde(default = "build_mixer_cfg_from_env")]
     pub mixer: MixerConfig,
 }
@@ -646,5 +647,26 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn mixer_env_var_fallback_is_read() {
+        use std::time::Duration;
+
+        // Baseline: no env vars → compiled-in defaults.
+        let base = build_mixer_cfg_from_env();
+        assert_eq!(base.delay_range, MixerConfig::default().delay_range);
+
+        // With env var set → value is picked up.
+        unsafe { std::env::set_var("HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS", "42") };
+        let with_env = build_mixer_cfg_from_env();
+        unsafe { std::env::remove_var("HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS") };
+        assert_eq!(with_env.delay_range, Duration::from_millis(42));
+
+        // SmartDefault path (hopr.network absent from YAML) also reads env vars.
+        unsafe { std::env::set_var("HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS", "7") };
+        let default_net = UserHoprNetworkConfig::default();
+        unsafe { std::env::remove_var("HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS") };
+        assert_eq!(default_net.mixer.delay_range, Duration::from_millis(7));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `mixer: MixerConfig` to `UserHoprNetworkConfig` with `#[serde(default = "build_mixer_cfg_from_env")]` and `#[default(build_mixer_cfg_from_env())]` — both YAML-absent and `::default()` paths read `HOPR_INTERNAL_MIXER_*` env vars, then fall back to compiled-in defaults (0 ms min, 20 ms spread, 20 000 capacity)
- Adds local `build_mixer_cfg_from_env()` (deleted from hoprnet upstream)
- Wires `mixer` through `From<UserHoprLibConfig> for HoprLibConfig` → `HoprProtocolConfig`
- Adds `explicit_mixer_section_round_trips` and `mixer_env_var_fallback_is_read` unit tests
- Bumps hoprnet rev to `8c04d91a` (typed `MixerConfig` on `HoprProtocolConfig`, merged)

## Depends on

- hoprnet/hoprnet#8152 ✅ merged