### PR TITLE
fix(localcluster): pre-announce using quic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-localcluster"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/localcluster/Cargo.toml
+++ b/localcluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-localcluster"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/localcluster/src/identity.rs
+++ b/localcluster/src/identity.rs
@@ -160,13 +160,13 @@ lazy_static::lazy_static! {
 /// blokli sees the same multiaddr from the pre-announce and hoprd startup,
 /// allowing hoprd to receive `AlreadyAnnounced` and skip the on-chain announce.
 ///
-/// IP addresses use `/ip4/<addr>/tcp/<port>`; all other values (including
-/// "localhost") use `/dns4/<host>/tcp/<port>`.
+/// IP addresses use `/ip4/<addr>/udp/<port>/quic-v1`; all other values
+/// (including "localhost") use `/dns4/<host>/udp/<port>/quic-v1`.
 fn build_announce_multiaddr(host: &str, port: u16) -> anyhow::Result<Multiaddr> {
     let s = if host.parse::<std::net::IpAddr>().is_ok() {
-        format!("/ip4/{host}/tcp/{port}")
+        format!("/ip4/{host}/udp/{port}/quic-v1")
     } else {
-        format!("/dns4/{host}/tcp/{port}")
+        format!("/dns4/{host}/udp/{port}/quic-v1")
     };
     s.parse().context("invalid pre-announce multiaddr")
 }


### PR DESCRIPTION
After #48, nodes announce using `quic`. 
However, the localcluster identities are still pre-announced using `tcp`. Thus when the node started up, the announced address differed from the expected address, and tries to re-announce.