### PR TITLE
chore: update hoprnet dependencies to f90796b

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "hopr-reference"
 version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4614,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4840,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=8c04d91a3310592b1bf36e48c531c4f31c67f38d#8c04d91a3310592b1bf36e48c531c4f31c67f38d"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "8c04d91a3310592b1bf36e48c531c4f31c67f38d", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
+hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }


### PR DESCRIPTION
## Summary

Bumps the `hoprnet` git dependencies from `8c04d91` to the latest `master` revision [`f90796b`](https://github.com/hoprnet/hoprnet/commit/f90796b38182d5741e783833a2af6163b21d3249).

Affected crates: `hopr-utils`, `hopr-chain-connector`, `hopr-ct-full-network`, `hopr-lib`, `hopr-network-graph`, `hopr-reference`, `hopr-strategy`, `hopr-transport-p2p`, `hopr-utils-session`.

## Changes

- `Cargo.toml`: updated the `rev` for all `hoprnet` git dependencies.
- `Cargo.lock`: regenerated entries for the updated revision.

## Verification

- `cargo check --workspace` passes (`Finished` in ~4m, exit 0).

https://claude.ai/code/session_01Nei9iMdYtrw4BcecWc4jTq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nei9iMdYtrw4BcecWc4jTq)_