### PR TITLE
feat(build): enable aarch64-apple-darwin AES hardware acceleration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Enable hardware AES intrinsics on Apple Silicon — selects aes::armv8 backend
+# at compile time instead of aes::soft::fixslice. The aes crate v0.8 requires
+# --cfg aes_armv8 (not just target-feature=+aes) to activate the armv8 module.
+# Restricted to aarch64-apple-darwin: Apple Silicon always has the AES crypto
+# extension; aarch64-unknown-linux-* cannot make that guarantee.
+[target.aarch64-apple-darwin]
+rustflags = ["--cfg", "aes_armv8", "-C", "target-feature=+aes,+neon"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@
 # Restricted to aarch64-apple-darwin: Apple Silicon always has the AES crypto
 # extension; aarch64-unknown-linux-* cannot make that guarantee.
 [target.aarch64-apple-darwin]
-rustflags = ["--cfg", "aes_armv8", "-C", "target-feature=+aes,+neon"]
+rustflags = ["--cfg=aes_armv8", "-Ctarget-feature=+aes,+neon"]


### PR DESCRIPTION
## Summary

- Adds `.cargo/config.toml` with `--cfg aes_armv8` and `-C target-feature=+aes,+neon` for the `aarch64-apple-darwin` target (Apple Silicon)
- Selects `aes::armv8::encdec` hardware backend at compile time instead of `aes::soft::fixslice`
- Restricted to `aarch64-apple-darwin` — Apple Silicon always has the AES crypto extension; `aarch64-unknown-linux-*` is excluded because older ARM cores (Cortex-A53 and earlier) lack it

**Why `--cfg aes_armv8` and not just `target-feature=+aes`:**
The `aes` crate v0.8 uses a custom cfg flag `aes_armv8` (not `target_feature`) to select the armv8 backend module. `target-feature=+aes` makes the instructions available to the compiler but the crate still compiles `soft::fixslice` unless `--cfg aes_armv8` is explicitly set.

**Binary verification (Apple M-series, from hoprnet/edge-client#83):**
```
$ nm target/release/<binary> | c++filt | grep "^[^ ]* [tT] aes::"
aes::armv8::encdec::encrypt8::...
```
One `armv8` symbol, zero `soft::fixslice` symbols — hardware path confirmed.