### PR TITLE
fix(ci): enforce nix fmt --ci via Format matrix entry

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -76,10 +76,9 @@ jobs:
           fi
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@18b6c2fec0b8f0240a83d2099cb40301c06585a0 # workflow-checks-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      format: true
       runner_small: depot-ubuntu-24.04
       runner_large: depot-ubuntu-24.04-4
     secrets:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -76,9 +76,10 @@ jobs:
           fi
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@bbd22e57cf954c15f0a6051d59329857809141dd # workflow-checks-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@18b6c2fec0b8f0240a83d2099cb40301c06585a0 # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      format: true
       runner_small: depot-ubuntu-24.04
       runner_large: depot-ubuntu-24.04-4
     secrets:


### PR DESCRIPTION
## Summary

- Adds `format: true` to the `checks:` CI job, enabling the new first-class `Format` matrix entry from [hopr-workflows#77](https://github.com/hoprnet/hopr-workflows/pull/77) (merged, tagged `workflow-checks-v2`)
- The `Format` job runs `nix fmt -- --ci` (treefmt: `--no-cache --fail-on-change`) as the first step so cheap formatting violations surface before heavier checks
- The repo is already clean (`nix fmt -- --ci` exits 0 on main)