### PR TITLE
refactor(deps): migrate hopr-reference → hopr-lib builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,8 +1555,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c49aad21c0d9dac90f52c45894e7f23a7201d0264c07a4546c1df603ca3158"
 dependencies = [
  "anyhow",
+ "async-broadcast",
  "async-trait",
  "bytes",
+ "chrono",
  "cynic",
  "cynic-codegen",
  "eventsource-client",
@@ -1565,9 +1567,13 @@ dependencies = [
  "hex",
  "hopr-types",
  "http",
+ "indexmap 2.14.0",
  "launchdarkly-sdk-transport",
+ "parking_lot",
+ "rand 0.10.1",
  "reqwest 0.12.28",
  "semver 1.0.28",
+ "serde",
  "serde_json",
  "smart-default",
  "strum 0.28.0",
@@ -4360,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4372,6 +4378,7 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-time",
+ "hex",
  "hopr-api",
  "hopr-utils",
  "moka",
@@ -4389,7 +4396,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4440,18 +4447,28 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-time",
+ "hex-literal",
  "hopr-api",
+ "hopr-chain-connector",
+ "hopr-ct-full-network",
+ "hopr-network-graph",
+ "hopr-session-server-forwarder",
+ "hopr-ticket-manager",
  "hopr-transport",
+ "hopr-transport-p2p",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
+ "rand 0.10.1",
+ "rstest",
  "serde",
  "serde_with",
  "smart-default",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "validator",
 ]
@@ -4459,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4474,29 +4491,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-node"
-version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
-dependencies = [
- "anyhow",
- "futures",
- "hopr-api",
- "hopr-chain-connector",
- "hopr-ct-full-network",
- "hopr-lib",
- "hopr-network-graph",
- "hopr-session-server-forwarder",
- "hopr-ticket-manager",
- "hopr-transport-p2p",
- "tokio",
- "tracing",
- "validator",
-]
-
-[[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4509,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4539,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4570,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4585,14 +4582,16 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "async-trait",
  "hopr-api",
- "hopr-lib",
+ "hopr-transport-session",
+ "hopr-utils",
  "serde",
  "serde_with",
  "smart-default",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
  "tracing",
@@ -4602,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4627,7 +4626,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4649,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4691,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4708,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4728,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4753,7 +4752,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4786,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4853,7 +4852,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4883,7 +4882,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4922,8 +4921,9 @@ dependencies = [
  "hopr-ct-full-network",
  "hopr-lib",
  "hopr-network-graph",
- "hopr-node",
+ "hopr-session-server-forwarder",
  "hopr-strategy",
+ "hopr-ticket-manager",
  "hopr-transport-p2p",
  "hopr-utils-session",
  "hoprd-api",
@@ -5025,7 +5025,7 @@ dependencies = [
  "futures",
  "hopr-chain-connector",
  "hopr-lib",
- "hopr-node",
+ "hopr-session-server-forwarder",
  "hopr-strategy",
  "hoprd",
  "hoprd-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4474,9 +4474,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "hopr-node"
+version = "0.1.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
+dependencies = [
+ "anyhow",
+ "futures",
+ "hopr-api",
+ "hopr-chain-connector",
+ "hopr-ct-full-network",
+ "hopr-lib",
+ "hopr-network-graph",
+ "hopr-session-server-forwarder",
+ "hopr-ticket-manager",
+ "hopr-transport-p2p",
+ "tokio",
+ "tracing",
+ "validator",
+]
+
+[[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4489,7 +4509,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4519,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4550,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4563,20 +4583,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-reference"
-version = "4.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+name = "hopr-session-server-forwarder"
+version = "0.1.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
- "anyhow",
  "async-trait",
- "futures",
  "hopr-api",
- "hopr-chain-connector",
- "hopr-ct-full-network",
  "hopr-lib",
- "hopr-network-graph",
- "hopr-ticket-manager",
- "hopr-transport-p2p",
  "serde",
  "serde_with",
  "smart-default",
@@ -4589,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4613,8 +4626,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+version = "0.5.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4635,8 +4648,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+version = "0.28.5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4678,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4695,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4715,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4740,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4773,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4840,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4870,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f90796b38182d5741e783833a2af6163b21d3249#f90796b38182d5741e783833a2af6163b21d3249"
+source = "git+https://github.com/hoprnet/hoprnet?rev=43cc54d43d5f20ec71c20764eaba7afb49af6f41#43cc54d43d5f20ec71c20764eaba7afb49af6f41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4909,7 +4922,7 @@ dependencies = [
  "hopr-ct-full-network",
  "hopr-lib",
  "hopr-network-graph",
- "hopr-reference",
+ "hopr-node",
  "hopr-strategy",
  "hopr-transport-p2p",
  "hopr-utils-session",
@@ -5012,7 +5025,7 @@ dependencies = [
  "futures",
  "hopr-chain-connector",
  "hopr-lib",
- "hopr-reference",
+ "hopr-node",
  "hopr-strategy",
  "hoprd",
  "hoprd-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4396,7 +4396,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4436,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4452,7 +4452,6 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-ct-full-network",
  "hopr-network-graph",
- "hopr-session-server-forwarder",
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
@@ -4476,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4493,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4506,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4536,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4567,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4582,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4601,7 +4600,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4626,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4648,7 +4647,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.28.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4690,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4707,7 +4706,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4727,7 +4726,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4752,7 +4751,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4785,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4852,7 +4851,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4882,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b128645cd89181b27d8a133370cf8208d5bdc12e#b128645cd89181b27d8a133370cf8208d5bdc12e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
-hopr-reference = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "f90796b38182d5741e783833a2af6163b21d3249", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
+hopr-node = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
-hopr-node = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "43cc54d43d5f20ec71c20764eaba7afb49af6f41", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
+hopr-node = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
-hopr-node = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "353aa4d21e30ddf6b22ab1bfefedacdc078aaa88", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "b128645cd89181b27d8a133370cf8208d5bdc12e", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -71,7 +71,7 @@ allocator-jemalloc-stats = [
   "dep:tikv-jemalloc-ctl",
   "dep:humansize",
 ]
-session-server = ["hopr-lib/session-server", "hopr-reference/session-server"]
+session-server = ["hopr-lib/session-server", "hopr-node/session-server"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -123,7 +123,7 @@ hopr-lib = { workspace = true, features = [
 hopr-utils-session = { workspace = true }
 hoprd-api = { workspace = true, features = ["telemetry"] }
 # impls
-hopr-reference = { workspace = true, features = [
+hopr-node = { workspace = true, features = [
   "runtime-tokio",
   "session-client",
 ] }

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -71,7 +71,7 @@ allocator-jemalloc-stats = [
   "dep:tikv-jemalloc-ctl",
   "dep:humansize",
 ]
-session-server = ["hopr-lib/session-server", "hopr-node/session-server"]
+session-server = ["hopr-lib/session-server"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -122,14 +122,11 @@ hopr-lib = { workspace = true, features = [
 ] }
 hopr-utils-session = { workspace = true }
 hoprd-api = { workspace = true, features = ["telemetry"] }
-# impls
-hopr-node = { workspace = true, features = [
-  "runtime-tokio",
-  "session-client",
-] }
 hopr-chain-connector = { workspace = true }
 hopr-ct-full-network = { workspace = true }
 hopr-network-graph = { workspace = true, features = ["petgraph"] }
+hopr-session-server-forwarder = { workspace = true, features = ["runtime-tokio"] }
+hopr-ticket-manager = { workspace = true }
 hopr-transport-p2p = { workspace = true }
 
 # Target-specific dependencies for memory allocators

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -125,7 +125,9 @@ hoprd-api = { workspace = true, features = ["telemetry"] }
 hopr-chain-connector = { workspace = true }
 hopr-ct-full-network = { workspace = true }
 hopr-network-graph = { workspace = true, features = ["petgraph"] }
-hopr-session-server-forwarder = { workspace = true, features = ["runtime-tokio"] }
+hopr-session-server-forwarder = { workspace = true, features = [
+  "runtime-tokio",
+] }
 hopr-ticket-manager = { workspace = true }
 hopr-transport-p2p = { workspace = true }
 

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -8,7 +8,7 @@ use hopr_lib::{
     },
     exports::transport::{HoprProtocolConfig, TagAllocatorConfig, config::HoprCodecConfig},
 };
-use hopr_reference::config::SessionIpForwardingConfig;
+use hopr_node::config::SessionIpForwardingConfig;
 use hoprd_api::config::{Api, Auth};
 use proc_macro_regex::regex;
 use serde::{Deserialize, Serialize};

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -8,7 +8,7 @@ use hopr_lib::{
     },
     exports::transport::{HoprProtocolConfig, TagAllocatorConfig, config::HoprCodecConfig},
 };
-use hopr_node::config::SessionIpForwardingConfig;
+use hopr_session_server_forwarder::config::SessionIpForwardingConfig;
 use hoprd_api::config::{Api, Auth};
 use proc_macro_regex::regex;
 use serde::{Deserialize, Serialize};
@@ -310,6 +310,7 @@ impl From<UserHoprLibConfig> for HoprLibConfig {
                 path_planner: Default::default(),
                 counter_flush_interval: HoprProtocolConfig::default().counter_flush_interval,
                 mixer: value.network.mixer,
+                stream: Default::default(),
             },
             ..Default::default()
         }

--- a/hoprd/src/lib.rs
+++ b/hoprd/src/lib.rs
@@ -32,6 +32,7 @@ use hopr_lib::builder::HoprBuilder;
 use hopr_lib::config::HoprLibConfig;
 use hopr_lib::{AbortableList, HoprKeys, api::types::crypto::keypairs::Keypair};
 use hopr_network_graph::{ChannelGraph, SharedChannelGraph};
+#[cfg(feature = "session-server")]
 use hopr_session_server_forwarder::HoprServerIpForwardingReactor;
 use hopr_ticket_manager::{HoprTicketManager, RedbStore, RedbTicketQueue, ticket_manager_from_chain};
 use hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork, PeerDiscovery};
@@ -150,53 +151,54 @@ pub async fn main_inner(cfg: HoprdConfig, hopr_keys: HoprKeys) -> anyhow::Result
     let graph_for_ct = graph.clone();
     let safe_address = hopr_lib_cfg.safe_module.safe_address;
     let module_address = hopr_lib_cfg.safe_module.module_address;
+    #[cfg(feature = "session-server")]
     let server = HoprServerIpForwardingReactor::new(
         hopr_keys.packet_key.clone(),
         cfg.session_ip_forwarding.clone(),
     );
 
-    let node = Arc::new(
-        HoprBuilder
-            .with_identity(&hopr_keys.chain_key, &hopr_keys.packet_key)
-            .with_config(hopr_lib_cfg)
-            .with_safe_module(&safe_address, &module_address)
-            .with_chain_api(move |_ctx| chain_connector)
-            .with_graph(move |_ctx| graph)
-            .with_network(move |ctx| {
-                Box::pin(async move {
-                    let peer_discovery_rx = ctx
-                        .take_peer_discovery_rx()
-                        .ok_or(hopr_lib::errors::HoprLibError::BuilderError(
-                            "peer_discovery_rx already taken",
-                        ))?;
-                    let multiaddresses = vec![(&ctx.cfg.host)
-                        .try_into()
-                        .map_err(hopr_lib::errors::HoprLibError::TransportError)?];
-                    let nb = HoprLibp2pNetworkBuilder::new(
-                        peer_discovery_rx
-                            .map(|(peer_id, addrs)| PeerDiscovery::Announce(peer_id, addrs)),
-                    );
-                    nb.build(
-                        &ctx.packet_key,
-                        multiaddresses,
-                        "/hopr/mix/1.1.0",
-                        ctx.cfg.protocol.transport.prefer_local_addresses,
-                    )
-                    .await
-                    .map_err(|e| hopr_lib::errors::HoprLibError::GeneralError(e.to_string()))
-                })
-            })
-            .with_cover_traffic(move |ctx| {
-                hopr_ct_full_network::FullNetworkDiscovery::new(
-                    *ctx.packet_key.public(),
-                    prober_cfg,
-                    graph_for_ct,
+    let builder = HoprBuilder
+        .with_identity(&hopr_keys.chain_key, &hopr_keys.packet_key)
+        .with_config(hopr_lib_cfg)
+        .with_safe_module(&safe_address, &module_address)
+        .with_chain_api(move |_ctx| chain_connector)
+        .with_graph(move |_ctx| graph)
+        .with_network(move |ctx| {
+            Box::pin(async move {
+                let peer_discovery_rx = ctx
+                    .take_peer_discovery_rx()
+                    .ok_or(hopr_lib::errors::HoprLibError::BuilderError(
+                        "peer_discovery_rx already taken",
+                    ))?;
+                let multiaddresses = vec![(&ctx.cfg.host)
+                    .try_into()
+                    .map_err(hopr_lib::errors::HoprLibError::TransportError)?];
+                let nb = HoprLibp2pNetworkBuilder::new(
+                    peer_discovery_rx
+                        .map(|(peer_id, addrs)| PeerDiscovery::Announce(peer_id, addrs)),
+                );
+                nb.build(
+                    &ctx.packet_key,
+                    multiaddresses,
+                    "/hopr/mix/1.1.0",
+                    ctx.cfg.protocol.transport.prefer_local_addresses,
                 )
+                .await
+                .map_err(|e| hopr_lib::errors::HoprLibError::GeneralError(e.to_string()))
             })
-            .with_session_server(server)
-            .build_full(ticket_manager, ticket_factory)
-            .await?,
-    );
+        })
+        .with_cover_traffic(move |ctx| {
+            hopr_ct_full_network::FullNetworkDiscovery::new(
+                *ctx.packet_key.public(),
+                prober_cfg,
+                graph_for_ct,
+            )
+        });
+
+    #[cfg(feature = "session-server")]
+    let node = Arc::new(builder.with_session_server(server).build_full(ticket_manager, ticket_factory).await?);
+    #[cfg(not(feature = "session-server"))]
+    let node = Arc::new(builder.build_full(ticket_manager, ticket_factory).await?);
 
     if cfg.api.enable {
         let list = init_rest_api(&cfg, node.clone()).await?;

--- a/hoprd/src/lib.rs
+++ b/hoprd/src/lib.rs
@@ -28,18 +28,21 @@ use hopr_chain_connector::{
     BlockchainConnectorConfig, blokli_client, create_trustful_hopr_blokli_connector,
 };
 use hopr_chain_connector::{HoprBlockchainSafeConnector, blokli_client::BlokliClient};
+use hopr_lib::builder::HoprBuilder;
 use hopr_lib::config::HoprLibConfig;
 use hopr_lib::{AbortableList, HoprKeys, api::types::crypto::keypairs::Keypair};
-use hopr_network_graph::SharedChannelGraph;
-use hopr_node::exit::HoprServerIpForwardingReactor;
-use hopr_transport_p2p::HoprNetwork;
+use hopr_network_graph::{ChannelGraph, SharedChannelGraph};
+use hopr_session_server_forwarder::HoprServerIpForwardingReactor;
+use hopr_ticket_manager::{HoprTicketManager, RedbStore, RedbTicketQueue, ticket_manager_from_chain};
+use hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork, PeerDiscovery};
 
 type HoprBlokliConnector = HoprBlockchainSafeConnector<BlokliClient>;
+type SharedTicketManager = Arc<HoprTicketManager<RedbStore, RedbTicketQueue>>;
 type HoprNode = hopr_lib::Hopr<
     Arc<HoprBlokliConnector>,
     SharedChannelGraph,
     HoprNetwork,
-    hopr_node::SharedTicketManager,
+    SharedTicketManager,
 >;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, strum::Display)]
@@ -132,19 +135,68 @@ pub async fn main_inner(cfg: HoprdConfig, hopr_keys: HoprKeys) -> anyhow::Result
         shuffle_ttl: cfg.hopr.network.probe_interval * 2,
         ..Default::default()
     };
+    prober_cfg.validate_against_probe_timeout(hopr_lib_cfg.protocol.probe.timeout)?;
 
-    let node = hopr_node::build_full_with_chain(
-        &hopr_keys.chain_key,
-        &hopr_keys.packet_key,
-        hopr_lib_cfg,
-        Some(prober_cfg),
-        chain_connector.clone(),
-        HoprServerIpForwardingReactor::new(
-            hopr_keys.packet_key.clone(),
-            cfg.session_ip_forwarding.clone(),
-        ),
-    )
-    .await?;
+    let (ticket_manager, ticket_factory) = ticket_manager_from_chain(&chain_connector)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to seed ticket manager: {e}"))?;
+
+    let path_cfg = hopr_lib_cfg.protocol.path_planner;
+    let graph: SharedChannelGraph = Arc::new(ChannelGraph::with_edge_params(
+        *hopr_keys.packet_key.public(),
+        path_cfg.edge_penalty,
+        path_cfg.min_ack_rate,
+    ));
+    let graph_for_ct = graph.clone();
+    let safe_address = hopr_lib_cfg.safe_module.safe_address;
+    let module_address = hopr_lib_cfg.safe_module.module_address;
+    let server = HoprServerIpForwardingReactor::new(
+        hopr_keys.packet_key.clone(),
+        cfg.session_ip_forwarding.clone(),
+    );
+
+    let node = Arc::new(
+        HoprBuilder
+            .with_identity(&hopr_keys.chain_key, &hopr_keys.packet_key)
+            .with_config(hopr_lib_cfg)
+            .with_safe_module(&safe_address, &module_address)
+            .with_chain_api(move |_ctx| chain_connector)
+            .with_graph(move |_ctx| graph)
+            .with_network(move |ctx| {
+                Box::pin(async move {
+                    let peer_discovery_rx = ctx
+                        .take_peer_discovery_rx()
+                        .ok_or(hopr_lib::errors::HoprLibError::BuilderError(
+                            "peer_discovery_rx already taken",
+                        ))?;
+                    let multiaddresses = vec![(&ctx.cfg.host)
+                        .try_into()
+                        .map_err(hopr_lib::errors::HoprLibError::TransportError)?];
+                    let nb = HoprLibp2pNetworkBuilder::new(
+                        peer_discovery_rx
+                            .map(|(peer_id, addrs)| PeerDiscovery::Announce(peer_id, addrs)),
+                    );
+                    nb.build(
+                        &ctx.packet_key,
+                        multiaddresses,
+                        "/hopr/mix/1.1.0",
+                        ctx.cfg.protocol.transport.prefer_local_addresses,
+                    )
+                    .await
+                    .map_err(|e| hopr_lib::errors::HoprLibError::GeneralError(e.to_string()))
+                })
+            })
+            .with_cover_traffic(move |ctx| {
+                hopr_ct_full_network::FullNetworkDiscovery::new(
+                    *ctx.packet_key.public(),
+                    prober_cfg,
+                    graph_for_ct,
+                )
+            })
+            .with_session_server(server)
+            .build_full(ticket_manager, ticket_factory)
+            .await?,
+    );
 
     if cfg.api.enable {
         let list = init_rest_api(&cfg, node.clone()).await?;

--- a/hoprd/src/lib.rs
+++ b/hoprd/src/lib.rs
@@ -31,7 +31,7 @@ use hopr_chain_connector::{HoprBlockchainSafeConnector, blokli_client::BlokliCli
 use hopr_lib::config::HoprLibConfig;
 use hopr_lib::{AbortableList, HoprKeys, api::types::crypto::keypairs::Keypair};
 use hopr_network_graph::SharedChannelGraph;
-use hopr_reference::exit::HoprServerIpForwardingReactor;
+use hopr_node::exit::HoprServerIpForwardingReactor;
 use hopr_transport_p2p::HoprNetwork;
 
 type HoprBlokliConnector = HoprBlockchainSafeConnector<BlokliClient>;
@@ -39,7 +39,7 @@ type HoprNode = hopr_lib::Hopr<
     Arc<HoprBlokliConnector>,
     SharedChannelGraph,
     HoprNetwork,
-    hopr_reference::SharedTicketManager,
+    hopr_node::SharedTicketManager,
 >;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, strum::Display)]
@@ -133,7 +133,7 @@ pub async fn main_inner(cfg: HoprdConfig, hopr_keys: HoprKeys) -> anyhow::Result
         ..Default::default()
     };
 
-    let node = hopr_reference::build_full_with_chain(
+    let node = hopr_node::build_full_with_chain(
         &hopr_keys.chain_key,
         &hopr_keys.packet_key,
         hopr_lib_cfg,

--- a/hoprd/src/lib.rs
+++ b/hoprd/src/lib.rs
@@ -34,17 +34,15 @@ use hopr_lib::{AbortableList, HoprKeys, api::types::crypto::keypairs::Keypair};
 use hopr_network_graph::{ChannelGraph, SharedChannelGraph};
 #[cfg(feature = "session-server")]
 use hopr_session_server_forwarder::HoprServerIpForwardingReactor;
-use hopr_ticket_manager::{HoprTicketManager, RedbStore, RedbTicketQueue, ticket_manager_from_chain};
+use hopr_ticket_manager::{
+    HoprTicketManager, RedbStore, RedbTicketQueue, ticket_manager_from_chain,
+};
 use hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork, PeerDiscovery};
 
 type HoprBlokliConnector = HoprBlockchainSafeConnector<BlokliClient>;
 type SharedTicketManager = Arc<HoprTicketManager<RedbStore, RedbTicketQueue>>;
-type HoprNode = hopr_lib::Hopr<
-    Arc<HoprBlokliConnector>,
-    SharedChannelGraph,
-    HoprNetwork,
-    SharedTicketManager,
->;
+type HoprNode =
+    hopr_lib::Hopr<Arc<HoprBlokliConnector>, SharedChannelGraph, HoprNetwork, SharedTicketManager>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, strum::Display)]
 enum HoprdProcess {
@@ -165,14 +163,14 @@ pub async fn main_inner(cfg: HoprdConfig, hopr_keys: HoprKeys) -> anyhow::Result
         .with_graph(move |_ctx| graph)
         .with_network(move |ctx| {
             Box::pin(async move {
-                let peer_discovery_rx = ctx
-                    .take_peer_discovery_rx()
-                    .ok_or(hopr_lib::errors::HoprLibError::BuilderError(
-                        "peer_discovery_rx already taken",
-                    ))?;
-                let multiaddresses = vec![(&ctx.cfg.host)
-                    .try_into()
-                    .map_err(hopr_lib::errors::HoprLibError::TransportError)?];
+                let peer_discovery_rx = ctx.take_peer_discovery_rx().ok_or(
+                    hopr_lib::errors::HoprLibError::BuilderError("peer_discovery_rx already taken"),
+                )?;
+                let multiaddresses = vec![
+                    (&ctx.cfg.host)
+                        .try_into()
+                        .map_err(hopr_lib::errors::HoprLibError::TransportError)?,
+                ];
                 let nb = HoprLibp2pNetworkBuilder::new(
                     peer_discovery_rx
                         .map(|(peer_id, addrs)| PeerDiscovery::Announce(peer_id, addrs)),
@@ -196,7 +194,12 @@ pub async fn main_inner(cfg: HoprdConfig, hopr_keys: HoprKeys) -> anyhow::Result
         });
 
     #[cfg(feature = "session-server")]
-    let node = Arc::new(builder.with_session_server(server).build_full(ticket_manager, ticket_factory).await?);
+    let node = Arc::new(
+        builder
+            .with_session_server(server)
+            .build_full(ticket_manager, ticket_factory)
+            .await?,
+    );
     #[cfg(not(feature = "session-server"))]
     let node = Arc::new(builder.build_full(ticket_manager, ticket_factory).await?);
 

--- a/localcluster/Cargo.toml
+++ b/localcluster/Cargo.toml
@@ -26,7 +26,7 @@ hopr-strategy = { workspace = true, features = [
   "strategy-channel-lifecycle",
 ] }
 hopr-lib = { workspace = true }
-hopr-reference = { workspace = true, features = [
+hopr-node = { workspace = true, features = [
   "runtime-tokio",
   "session-server",
 ] }

--- a/localcluster/Cargo.toml
+++ b/localcluster/Cargo.toml
@@ -26,10 +26,7 @@ hopr-strategy = { workspace = true, features = [
   "strategy-channel-lifecycle",
 ] }
 hopr-lib = { workspace = true }
-hopr-node = { workspace = true, features = [
-  "runtime-tokio",
-  "session-server",
-] }
+hopr-session-server-forwarder = { workspace = true }
 hoprd-api-client = { workspace = true }
 hoprd-api = { workspace = true }
 lazy_static = { workspace = true }

--- a/localcluster/src/identity.rs
+++ b/localcluster/src/identity.rs
@@ -19,7 +19,7 @@ use hopr_lib::{
     },
     config::SafeModule,
 };
-use hopr_node::config::SessionIpForwardingConfig;
+use hopr_session_server_forwarder::config::SessionIpForwardingConfig;
 use hopr_strategy::{
     auto_redeeming::AutoRedeemingStrategyConfig,
     channel_lifecycle::{ChannelLifecycleConfig, PopulationConfig},

--- a/localcluster/src/identity.rs
+++ b/localcluster/src/identity.rs
@@ -19,7 +19,7 @@ use hopr_lib::{
     },
     config::SafeModule,
 };
-use hopr_reference::config::SessionIpForwardingConfig;
+use hopr_node::config::SessionIpForwardingConfig;
 use hopr_strategy::{
     auto_redeeming::AutoRedeemingStrategyConfig,
     channel_lifecycle::{ChannelLifecycleConfig, PopulationConfig},


### PR DESCRIPTION
Adapts `hoprd` after `hopr-node-assembly` was deleted in hoprnet/hoprnet#8176 — calls `HoprBuilder` directly.

**Changes:**
- `HoprServerIpForwardingReactor` construction and `.with_session_server()` call are gated on `#[cfg(feature = "session-server")]` so `hoprd --no-default-features` (used by `hoprd-localcluster`) compiles without the forwarder.
- `EchoServer` trait impl path updated to `hopr_api::node::HoprSessionServer`.
- hoprnet rev bumped to master (`b5ee506`).
- `nix fmt` applied.

**Depends on:** hoprnet/hoprnet#8174, hoprnet/hoprnet#8175, hoprnet/hoprnet#8176