### PR TITLE
chore: add renovate-config-validator pre-commit hook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -530,6 +530,7 @@
                 enable = true;
                 name = "Renovate config validator";
                 entry = "${pkgs.writeShellScript "validate-renovate" ''
+                  if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
                   ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
                 ''}";
                 files = "renovate\\.json$";

--- a/flake.nix
+++ b/flake.nix
@@ -526,6 +526,16 @@
               check-merge-conflicts.enable = true;
               check-added-large-files.enable = true;
               commitizen.enable = true;
+              renovate-config-validator = {
+                enable = true;
+                name = "Renovate config validator";
+                entry = "${pkgs.writeShellScript "validate-renovate" ''
+                  ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
+                ''}";
+                files = "renovate\\.json$";
+                language = "system";
+                pass_filenames = true;
+              };
             };
           };
 


### PR DESCRIPTION
Validates renovate.json on every commit via renovate-config-validator, using pkgs.nodejs/npx pinned through the flake's nixpkgs input.