### PR TITLE
feat(ci): add actionlint + pinact pre-commit hooks for workflow validation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - depot-ubuntu-24.04
+    - depot-ubuntu-24.04-4

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
+---
 self-hosted-runner:
   labels:
     - depot-ubuntu-24.04

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,3 +7,4 @@ self-hosted-runner:
     - depot-ubuntu-24.04-16
     - depot-ubuntu-24.04-arm-4
     - depot-ubuntu-24.04-arm-8
+    - depot-macos-15

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,7 @@ self-hosted-runner:
   labels:
     - depot-ubuntu-24.04
     - depot-ubuntu-24.04-4
+    - depot-ubuntu-24.04-8
+    - depot-ubuntu-24.04-16
+    - depot-ubuntu-24.04-arm-4
+    - depot-ubuntu-24.04-arm-8

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -206,13 +206,13 @@ jobs:
           BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+          cacheKeysForPR=$(gh actions-cache list -R "$REPO" -B "$BRANCH" | cut -f 1 )
 
           set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-            gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+            gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
           done
           echo "Done"
         env:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -38,9 +38,10 @@ jobs:
             build_command: nix build -L .#binary-hoprd-localcluster-x86_64-linux
             build_file: ./localcluster/Cargo.toml
             binary: hoprd-localcluster
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@b063eebe2dfb2f92e7177a8f81383aaac4835d09 # build-binaries-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@b4ee9597f2c47f62fbc2c989a4af36fc4abf2f6f
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.merge_commit_sha }}
       version_type: pr
@@ -50,14 +51,13 @@ jobs:
       binary: ${{ matrix.binary }}
       runner: ${{ matrix.runner }}
     secrets:
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       gpg_private_key: ${{ secrets.GPG_HOPRNET_PRIVATE_KEY }}
   build-docker:
     name: Docker
     needs: build-binaries
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@024a130d36187da87c46820d738ca737b1a9e716 # build-docker-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1
     permissions:
       contents: read
       pull-requests: write
@@ -85,7 +85,6 @@ jobs:
       deployment_namespace: core-team
       deployment_label_selector: app.kubernetes.io/component=node
     secrets:
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -138,9 +138,10 @@ jobs:
             build_file: ./localcluster/Cargo.toml
             binary: hoprd-localcluster
             required_label: ""
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@b063eebe2dfb2f92e7177a8f81383aaac4835d09 # build-binaries-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@b4ee9597f2c47f62fbc2c989a4af36fc4abf2f6f
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       version_type: commit
@@ -151,13 +152,12 @@ jobs:
       runner: ${{ matrix.runner }}
       enabled: ${{ matrix.required_label == '' || contains(github.event.pull_request.labels.*.name, matrix.required_label) }}
     secrets:
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       gpg_private_key: ${{ secrets.GPG_HOPRNET_PRIVATE_KEY }}
   build-docker:
     name: Docker
     needs: build-binaries
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@024a130d36187da87c46820d738ca737b1a9e716 # build-docker-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1
     permissions:
       contents: read
       pull-requests: write
@@ -180,7 +180,6 @@ jobs:
       deployment_namespace: core-team
       deployment_label_selector: app.kubernetes.io/component=node
     secrets:
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   docs:
     name: Docs

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -85,7 +85,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -102,7 +102,6 @@ jobs:
       runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   build-binaries:
     name: Binary ${{ matrix.binary }} ${{ matrix.architecture }}
     strategy:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,10 @@ jobs:
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-arm-8
             build_command: nix build -L .#binary-hoprd-aarch64-linux
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@b063eebe2dfb2f92e7177a8f81383aaac4835d09 # build-binaries-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@b4ee9597f2c47f62fbc2c989a4af36fc4abf2f6f
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.ref_name }}
       version_type: release
@@ -43,12 +44,11 @@ jobs:
       binary: hoprd
       runner: ${{ matrix.runner }}
     secrets:
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       gpg_private_key: ${{ secrets.GPG_HOPRNET_PRIVATE_KEY }}
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@024a130d36187da87c46820d738ca737b1a9e716 # build-docker-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@fa71078959cf9f892185e8df16551720693a2cd1
     needs: build-binaries
     permissions:
       contents: read
@@ -74,7 +74,6 @@ jobs:
       docker_image_name: hoprd
       docker_image_format: skopeo
     secrets:
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -86,12 +85,13 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     outputs:
       released_version: ${{ steps.release_version.outputs.current_version }}
     steps:
       - name: Release version
         id: release_version
-        uses: hoprnet/hopr-workflows/actions/release-version@53b6df9c98ee8a327d7533e76cd9aafcac6a1c2e # release-version-v4
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1
         with:
           source_branch: ${{ github.ref_name }}
           file: ./hoprd/Cargo.toml
@@ -101,9 +101,8 @@ jobs:
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_channel: HOPRd
           zulip_topic: Releases
-          gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
           gcp_artifact_package: hoprd
-          github_token: ${{ secrets.GH_RUNNER_TOKEN }}
+          github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}
   post-release:
     name: Post Release
     runs-on: depot-ubuntu-24.04

--- a/flake.nix
+++ b/flake.nix
@@ -529,10 +529,7 @@
               renovate-config-validator = {
                 enable = true;
                 name = "Renovate config validator";
-                entry = "${pkgs.writeShellScript "validate-renovate" ''
-                  if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
-                  ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
-                ''}";
+                entry = "${pkgs.renovate}/bin/renovate-config-validator";
                 files = "renovate\\.json$";
                 language = "system";
                 pass_filenames = true;
@@ -542,7 +539,15 @@
                 enable = true;
                 name = "pinact";
                 description = "Check GitHub Action refs are SHA-pinned and resolvable";
-                entry = "${pkgs.pinact}/bin/pinact run --check";
+                entry = "${pkgs.writeShellScript "pinact-check" ''
+                  token="''${GITHUB_TOKEN:-$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)}"
+                  if [ -z "$token" ]; then
+                    echo "pinact: skipping — no GITHUB_TOKEN and gh not authenticated" >&2
+                    exit 0
+                  fi
+                  export GITHUB_TOKEN="$token"
+                  exec ${pkgs.pinact}/bin/pinact run --check
+                ''}";
                 files = "^\\.github/workflows/.*\\.ya?ml$";
                 language = "system";
                 pass_filenames = false;

--- a/flake.nix
+++ b/flake.nix
@@ -556,6 +556,7 @@
             treefmtWrapper = config.treefmt.build.wrapper;
             treefmtPrograms = pkgs.lib.attrValues config.treefmt.build.programs;
             extraPackages = with pkgs; [
+              gh
               pkgs-unstable.cargo-audit
               cargo-machete
               cargo-shear
@@ -566,8 +567,8 @@
               envsubst
             ];
             shellHook = ''
-              ${pre-commit-check.shellHook}
               export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+              ${pre-commit-check.shellHook}
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -543,7 +543,7 @@
                 name = "pinact";
                 description = "Check GitHub Action refs are SHA-pinned and resolvable";
                 entry = "${pkgs.pinact}/bin/pinact run --check";
-                files = "\\.ya?ml$";
+                files = "^\\.github/workflows/.*\\.ya?ml$";
                 language = "system";
                 pass_filenames = false;
               };
@@ -567,7 +567,7 @@
             ];
             shellHook = ''
               ${pre-commit-check.shellHook}
-              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+              export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -537,6 +537,16 @@
                 language = "system";
                 pass_filenames = true;
               };
+              actionlint.enable = true;
+              pinact = {
+                enable = true;
+                name = "pinact";
+                description = "Check GitHub Action refs are SHA-pinned and resolvable";
+                entry = "${pkgs.pinact}/bin/pinact run --check";
+                files = "\\.ya?ml$";
+                language = "system";
+                pass_filenames = false;
+              };
             };
           };
 
@@ -557,6 +567,7 @@
             ];
             shellHook = ''
               ${pre-commit-check.shellHook}
+              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
             '';
           };
 

--- a/rest-api-client/src/codegen/mod.rs
+++ b/rest-api-client/src/codegen/mod.rs
@@ -280,8 +280,8 @@ pub mod types {
     ///  "description": "Standardized error response for the API",
     ///  "examples": [
     ///    {
-    ///      "error": "Invalid value passed in parameter 'XYZ'",
-    ///      "status": "INVALID_INPUT"
+    ///      "status": "INVALID_INPUT",
+    ///      "error": "Invalid value passed in parameter 'XYZ'"
     ///    }
     ///  ],
     ///  "type": "object",
@@ -621,8 +621,8 @@ pub mod types {
     ///  "description": "Parameters for enumerating channels.",
     ///  "examples": [
     ///    {
-    ///      "fullTopology": false,
-    ///      "includingClosed": true
+    ///      "includingClosed": true,
+    ///      "fullTopology": false
     ///    }
     ///  ],
     ///  "type": "object",
@@ -667,8 +667,8 @@ pub mod types {
     ///  "description": "Status of the channel after a close operation.",
     ///  "examples": [
     ///    {
-    ///      "channelStatus": "PendingToClose",
-    ///      "receipt": "0xd77da7c1821249e663dead1464d185c03223d9663a06bc1d46ed0ad449a07118"
+    ///      "receipt": "0xd77da7c1821249e663dead1464d185c03223d9663a06bc1d46ed0ad449a07118",
+    ///      "channelStatus": "PendingToClose"
     ///    }
     ///  ],
     ///  "type": "object",
@@ -767,9 +767,9 @@ pub mod types {
     ///  "examples": [
     ///    {
     ///      "address": "0xb4ce7e6e36ac8b01a974725d5ba730af2b156fbe",
-    ///      "averageLatency": 100,
-    ///      "lastUpdate": 1690000000000,
     ///      "probeRate": 0.476,
+    ///      "lastUpdate": 1690000000000,
+    ///      "averageLatency": 100,
     ///      "score": 0.7
     ///    }
     ///  ],
@@ -1028,10 +1028,10 @@ pub mod types {
     ///  "description": "Channel information as seen by the node.",
     ///  "examples": [
     ///    {
-    ///      "address": "0x188c4462b75e46f0c7262d7f48d182447b93a93c",
-    ///      "balance": "10 wxHOPR",
     ///      "id": "0x04efc1481d3f106b88527b3844ba40042b823218a9cd29d1aa11c2c2ef8f538f",
-    ///      "status": "Open"
+    ///      "address": "0x188c4462b75e46f0c7262d7f48d182447b93a93c",
+    ///      "status": "Open",
+    ///      "balance": "10 wxHOPR"
     ///    }
     ///  ],
     ///  "type": "object",
@@ -1089,14 +1089,14 @@ pub mod types {
     ///    {
     ///      "all": [
     ///        {
-    ///          "balance": "10 wxHOPR",
-    ///          "channelEpoch": 1,
     ///          "channelId": "0x04efc1481d3f106b88527b3844ba40042b823218a9cd29d1aa11c2c2ef8f538f",
-    ///          "closureTime": 0,
-    ///          "destination": "0x188c4462b75e46f0c7262d7f48d182447b93a93c",
     ///          "source": "0x07eaf07d6624f741e04f4092a755a9027aaab7f6",
+    ///          "destination": "0x188c4462b75e46f0c7262d7f48d182447b93a93c",
+    ///          "balance": "10 wxHOPR",
     ///          "status": "Open",
-    ///          "ticketIndex": 0
+    ///          "ticketIndex": 0,
+    ///          "channelEpoch": 1,
+    ///          "closureTime": 0
     ///        }
     ///      ],
     ///      "incoming": [],
@@ -1164,15 +1164,15 @@ and indexer state.*/
     ///      "announcedAddress": [
     ///        "/ip4/10.0.2.100/tcp/19092"
     ///      ],
-    ///      "chainStatus": "Ready",
+    ///      "providerUrl": "https://staging.blokli.hoprnet.link",
+    ///      "hoprNetworkName": "rotsee",
     ///      "channelClosurePeriod": 15,
     ///      "connectivityStatus": "Green",
-    ///      "hoprNetworkName": "rotsee",
+    ///      "chainStatus": "Ready",
     ///      "hoprNodeSafe": "0x42bc901b1d040f984ed626eff550718498a6798a",
     ///      "listeningAddress": [
     ///        "/ip4/10.0.2.100/tcp/19092"
-    ///      ],
-    ///      "providerUrl": "https://staging.blokli.hoprnet.link"
+    ///      ]
     ///    }
     ///  ],
     ///  "type": "object",
@@ -1292,16 +1292,16 @@ and indexer state.*/
     ///      "observed": [
     ///        "/ip4/10.0.2.100/tcp/19093"
     ///      ],
-    ///      "outgoingChannel": {
-    ///        "balance": "10 wxHOPR",
-    ///        "id": "0x04efc1481d3f106b88527b3844ba40042b823218a9cd29d1aa11c2c2ef8f538f",
-    ///        "status": "Open"
-    ///      },
     ///      "qos": {
-    ///        "averageLatency": 100,
-    ///        "lastUpdate": 1690000000000,
     ///        "probeRate": 0.476,
+    ///        "lastUpdate": 1690000000000,
+    ///        "averageLatency": 100,
     ///        "score": 0.7
+    ///      },
+    ///      "outgoingChannel": {
+    ///        "id": "0x04efc1481d3f106b88527b3844ba40042b823218a9cd29d1aa11c2c2ef8f538f",
+    ///        "status": "Open",
+    ///        "balance": "10 wxHOPR"
     ///      }
     ///    }
     ///  ],
@@ -1371,6 +1371,8 @@ and indexer state.*/
     ///{
     ///  "examples": [
     ///    {
+    ///      "overall": "Ready",
+    ///      "nodeState": "Node is running",
     ///      "components": {
     ///        "chain": {
     ///          "status": "Ready"
@@ -1381,9 +1383,7 @@ and indexer state.*/
     ///        "transport": {
     ///          "status": "Ready"
     ///        }
-    ///      },
-    ///      "nodeState": "Node is running",
-    ///      "overall": "Ready"
+    ///      }
     ///    }
     ///  ],
     ///  "type": "object",
@@ -1432,11 +1432,11 @@ and indexer state.*/
     ///  "description": "Received tickets statistics.",
     ///  "examples": [
     ///    {
+    ///      "winningCount": 0,
     ///      "neglectedValue": "0 wxHOPR",
     ///      "redeemedValue": "1000 wxHOPR",
     ///      "rejectedValue": "0 wxHOPR",
-    ///      "unredeemedValue": "2000 wxHOPR",
-    ///      "winningCount": 0
+    ///      "unredeemedValue": "2000 wxHOPR"
     ///    }
     ///  ],
     ///  "type": "object",
@@ -1618,9 +1618,9 @@ and indexer state.*/
     ///  "description": "Channel information for a specific peer.",
     ///  "examples": [
     ///    {
-    ///      "balance": "10 wxHOPR",
     ///      "id": "0x04efc1481d3f106b88527b3844ba40042b823218a9cd29d1aa11c2c2ef8f538f",
-    ///      "status": "Open"
+    ///      "status": "Open",
+    ///      "balance": "10 wxHOPR"
     ///    }
     ///  ],
     ///  "type": "object",
@@ -1667,9 +1667,9 @@ and indexer state.*/
     ///  "description": "QoS observation data for a peer.",
     ///  "examples": [
     ///    {
-    ///      "averageLatency": 100,
-    ///      "lastUpdate": 1690000000000,
     ///      "probeRate": 0.476,
+    ///      "lastUpdate": 1690000000000,
+    ///      "averageLatency": 100,
     ///      "score": 0.7
     ///    }
     ///  ],
@@ -1965,25 +1965,25 @@ If omitted, tickets in all channels are redeemed.*/
     ///  "description": "Request body for creating a new client session.",
     ///  "examples": [
     ///    {
-    ///      "capabilities": [
-    ///        "Retransmission",
-    ///        "Segmentation"
-    ///      ],
     ///      "destination": "0x1B482420Afa04aeC1Ef0e4a00C18451E84466c75",
     ///      "forwardPath": {
     ///        "Hops": 1
     ///      },
-    ///      "listenHost": "127.0.0.1:10000",
-    ///      "maxClientSessions": 2,
-    ///      "maxSurbUpstream": "2000 kb/s",
-    ///      "responseBuffer": "2 MB",
     ///      "returnPath": {
     ///        "Hops": 1
     ///      },
-    ///      "sessionPool": 0,
     ///      "target": {
     ///        "Plain": "localhost:8080"
-    ///      }
+    ///      },
+    ///      "listenHost": "127.0.0.1:10000",
+    ///      "capabilities": [
+    ///        "Retransmission",
+    ///        "Segmentation"
+    ///      ],
+    ///      "responseBuffer": "2 MB",
+    ///      "maxSurbUpstream": "2000 kb/s",
+    ///      "sessionPool": 0,
+    ///      "maxClientSessions": 2
     ///    }
     ///  ],
     ///  "type": "object",
@@ -2147,24 +2147,24 @@ Currently, the maximum value is 5.*/
     ///  "description": "Response body for creating a new client session.",
     ///  "examples": [
     ///    {
-    ///      "activeClients": [],
+    ///      "target": "example.com:80",
     ///      "destination": "0x5112D584a1C72Fc250176B57aEba5fFbbB287D8F",
     ///      "forwardPath": {
     ///        "Hops": 1
     ///      },
-    ///      "hoprMtu": 1002,
-    ///      "ip": "127.0.0.1",
-    ///      "maxClientSessions": 2,
-    ///      "maxSurbUpstream": "2000 kb/s",
-    ///      "port": 5542,
-    ///      "protocol": "tcp",
-    ///      "responseBuffer": "2 MB",
     ///      "returnPath": {
     ///        "Hops": 1
     ///      },
-    ///      "sessionPool": 0,
+    ///      "protocol": "tcp",
+    ///      "ip": "127.0.0.1",
+    ///      "port": 5542,
+    ///      "hoprMtu": 1002,
     ///      "surbLen": 398,
-    ///      "target": "example.com:80"
+    ///      "activeClients": [],
+    ///      "maxClientSessions": 2,
+    ///      "maxSurbUpstream": "2000 kb/s",
+    ///      "responseBuffer": "2 MB",
+    ///      "sessionPool": 0
     ///    }
     ///  ],
     ///  "type": "object",
@@ -2333,8 +2333,8 @@ This is useful for SURB balancing calculations.*/
     ///{
     ///  "examples": [
     ///    {
-    ///      "maxSurbUpstream": "2 Mbps",
-    ///      "responseBuffer": "2 MB"
+    ///      "responseBuffer": "2 MB",
+    ///      "maxSurbUpstream": "2 Mbps"
     ///    }
     ///  ],
     ///  "type": "object",


### PR DESCRIPTION
Pins all remaining action refs to SHAs and adds actionlint + pinact pre-commit hooks via the flake.

Note: run after WIF migration PR merges so pinact --check passes on hopr-workflows refs.