### PR TITLE
chore: bump the `hoprnet` related crates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,8 +8,6 @@ ignore = [
   "RUSTSEC-2026-0118", # `hickory-proto` 0.25.2 pulled by libp2p-dns 0.44.0 -> libp2p 0.56.0; no fix for 0.25.x; cannot remove without a major libp2p bump
   "RUSTSEC-2026-0119", # same root cause as 0118 (different advisory DB version); hickory-proto 0.25.2 still pulled by libp2p 0.56.0; remove together with 0118 once libp2p is bumped past 0.56.0
   "RUSTSEC-2026-0173", # 'proc-macro-error2' [unmaintained] via validator_derive 0.20 (validator 0.20 is latest; no fix yet)
-  "RUSTSEC-2026-0185", # 'quinn-proto' 0.11.14 remote memory exhaustion; fix requires >=0.11.15 upstream in hoprnet
-  "RUSTSEC-2026-0186", # 'memmap2' 0.9.10 unchecked pointer offset; transitive via hoprnet, no fix available yet
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,6 +8,8 @@ ignore = [
   "RUSTSEC-2026-0118", # `hickory-proto` 0.25.2 pulled by libp2p-dns 0.44.0 -> libp2p 0.56.0; no fix for 0.25.x; cannot remove without a major libp2p bump
   "RUSTSEC-2026-0119", # same root cause as 0118 (different advisory DB version); hickory-proto 0.25.2 still pulled by libp2p 0.56.0; remove together with 0118 once libp2p is bumped past 0.56.0
   "RUSTSEC-2026-0173", # 'proc-macro-error2' [unmaintained] via validator_derive 0.20 (validator 0.20 is latest; no fix yet)
+  "RUSTSEC-2026-0185", # 'quinn-proto' 0.11.14 remote memory exhaustion; fix requires >=0.11.15 upstream in hoprnet
+  "RUSTSEC-2026-0186", # 'memmap2' 0.9.10 unchecked pointer offset; transitive via hoprnet, no fix available yet
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4679,12 +4679,11 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.30.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+version = "0.29.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "ahash",
  "anyhow",
- "async-lock",
  "async-trait",
  "async_channel_io",
  "bytes",
@@ -4722,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4739,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4760,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4785,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4816,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4884,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4914,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,7 +2443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6342,9 +6342,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -7506,9 +7506,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,6 +2184,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossfire"
+version = "3.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8c4de3db833e7ef74050bae09d5f3fa8f9d1507d3c2689c6e8c50b71208b18"
+dependencies = [
+ "crossbeam-utils",
+ "embed-collections",
+ "futures-core",
+ "parking_lot",
+ "smallvec",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,6 +2716,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embed-collections"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49c327886cdc0e7eda24cd0827f195db19a5f941425914bc6db76c79c64bc21"
 
 [[package]]
 name = "embedded-io"
@@ -4395,7 +4414,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4426,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4449,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4466,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4505,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4524,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4537,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4567,7 +4586,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4598,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4613,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4632,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4658,7 +4677,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4680,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.31.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4688,8 +4707,8 @@ dependencies = [
  "async_channel_io",
  "bytes",
  "cfg-if",
+ "crossfire",
  "dashmap",
- "flume",
  "futures",
  "futures-time",
  "halfbrown",
@@ -4722,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4738,8 +4757,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+version = "0.9.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4753,6 +4772,7 @@ dependencies = [
  "libp2p-stream",
  "multiaddr",
  "pin-project",
+ "quinn-udp",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -4760,7 +4780,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4785,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4816,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4884,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4914,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d670a6c50517e50e400d40d21e2c11bd078461ac#d670a6c50517e50e400d40d21e2c11bd078461ac"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4679,8 +4679,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+version = "0.31.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4689,6 +4689,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "dashmap",
+ "flume",
  "futures",
  "futures-time",
  "halfbrown",
@@ -4721,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4738,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4759,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4784,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4815,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4883,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4913,7 +4914,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=51d0473ddbcc2b9dc97f0c0d956741ef726e1a49#51d0473ddbcc2b9dc97f0c0d956741ef726e1a49"
+source = "git+https://github.com/hoprnet/hoprnet?rev=64963285334fd26e304b392dc1b590c6e468b761#64963285334fd26e304b392dc1b590c6e468b761"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.29.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4721,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4883,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4394,8 +4394,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.21.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+version = "0.21.2"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4679,11 +4679,12 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+version = "0.30.0"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "ahash",
  "anyhow",
+ "async-lock",
  "async-trait",
  "async_channel_io",
  "bytes",
@@ -4721,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4738,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4759,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4784,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4815,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4883,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4913,7 +4914,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2#6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4495,6 +4495,8 @@ dependencies = [
  "indexmap 2.14.0",
  "parking_lot",
  "petgraph",
+ "rand 0.10.1",
+ "smallvec",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -4502,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4515,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4545,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4576,7 +4578,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4591,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4610,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4623,6 +4625,7 @@ dependencies = [
  "humantime-serde",
  "lazy_static",
  "moka",
+ "multiaddr",
  "parking_lot",
  "serde",
  "serde_with",
@@ -4635,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4656,8 +4659,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+version = "0.29.0"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4673,7 +4676,6 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-app",
  "hopr-protocol-hopr",
- "hopr-ticket-manager",
  "hopr-transport-mixer",
  "hopr-transport-probe",
  "hopr-transport-session",
@@ -4699,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4716,7 +4718,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4736,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4761,7 +4763,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4794,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4861,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4891,7 +4893,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=b5ee5069038ad8ef38f917e1b5a37c7331e2fe62#b5ee5069038ad8ef38f917e1b5a37c7331e2fe62"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8431,7 +8433,7 @@ checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4394,8 +4394,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+version = "0.21.1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4403,11 +4403,11 @@ dependencies = [
  "async-trait",
  "atomic_enum",
  "blokli-client",
+ "const-hex",
  "dashmap",
  "futures",
  "futures-concurrency",
  "futures-time",
- "hex",
  "hopr-api",
  "hopr-utils",
  "moka",
@@ -4420,19 +4420,20 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "validator",
 ]
 
 [[package]]
 name = "hopr-crypto-packet"
-version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+version = "1.4.0"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "bimap",
+ "const-hex",
  "curve25519-dalek",
  "elliptic-curve",
  "flagset",
  "generic-array 1.4.3",
- "hex",
  "hopr-types",
  "hopr-utils",
  "k256",
@@ -4448,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4464,8 +4465,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+version = "4.0.2-rc.5"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4504,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4523,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4535,8 +4536,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+version = "4.7.0"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4544,7 +4545,7 @@ dependencies = [
  "bloomfilter",
  "bytes",
  "cfg_eval",
- "hex",
+ "const-hex",
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
@@ -4566,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4597,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4612,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4631,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4657,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4678,8 +4679,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+version = "0.29.1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4720,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4736,8 +4737,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+version = "0.9.3"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4750,20 +4751,21 @@ dependencies = [
  "libp2p",
  "libp2p-stream",
  "multiaddr",
+ "pin-project",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+version = "0.7.0"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "anyhow",
  "async-trait",
+ "const-hex",
  "futures",
  "futures-concurrency",
- "hex",
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
@@ -4782,10 +4784,9 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "anyhow",
- "arrayvec",
  "async-trait",
  "flagset",
  "futures",
@@ -4795,7 +4796,6 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-transport-tag-allocator",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4883,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8398,7 +8398,7 @@ checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.29.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4721,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4883,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#03bcfd7198f7e2c25e2538185ac2a2153a6e1dfa"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.29.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4721,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4883,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=78e7c0408272f7fc7254cbaa5e81996f820dafb5#78e7c0408272f7fc7254cbaa5e81996f820dafb5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
+checksum = "b44937ce84d2cbf1ee4010667bd9214bb7db134a91dd9ffa6b1b8b1d6b030449"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
+checksum = "7bb0bdd61ddff726026676450e7e6a52c68aa39d98f2d60d05ad7caaea5b8100"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8b60d71b92824e095b4003ff01fd2bc923017b7568997c5f459240e83499c"
+checksum = "b1475c7edc6780b1759ccdb7960e28d29856ecbed47cfcf9e25be6a5f48b0cfb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.7"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+checksum = "17201e6cbb4efbb1e510b0746839cd743a5cec3fcfb4673ea2342bd657341c93"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
+checksum = "154b0f566ebbfc256b63c8d643c6a299f40a6fcd50a9d756c1d191487dd06483"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
+checksum = "a0a930a68a6f0ac19231bc2f5f0bf13fad3a26fa7df2525354890c72366c2998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
+checksum = "2e92108767c8c95b5e521570e039e374e65198c4179a98d200412c083d6c26d5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
+checksum = "c4546c9fae2861d4159ee3b25c44ab3edb90f21b849e86cf2086cacb1d56d8ac"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
+checksum = "ca2c325d5934445209c8d22fc67d27e2cf9fb79054b8154d9e522d6a4ee3a4f7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f2f7dac66147d165063c670dabca7b34807428130bef4583a7976523140f8d"
+checksum = "23b1e225c8715a0aaefeec2e5f5390881b6bc11606bb81c3470ba219eb04c350"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
+checksum = "ff4536d25780fcf51a338c26153c526c99649be1273600684ef10b397a207d4a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -501,14 +501,14 @@ checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
+checksum = "7f8d765656f02f993fa0565abeb3554ccd6a0d72ea44ce0558b983136639bd6b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052c031d1f7c5611997056bbcb8814e5cbf20f7efeee8c3de690555172038cf2"
+checksum = "2a05ef5b11fad72068e6f011c21445bc5b596ac850644c4a14c30d845ce56de8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
+checksum = "7c1fa8062c379d4fb51d28361cd02cd6a18a49fa79831c16831449b65408aa6c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
+checksum = "b06bfe79149dd53de5b196aa3c96db0500b7cf0ed72dbd1a31bac7660bc7cc65"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
+checksum = "b41d1a11f58b456c199e04591befc64cb236fa2574a7275a07b98b173727bd39"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
+checksum = "bcf028ac8bcb161ad7c104243e710cece8e1a794f65ee6c35c4c4d693c8e80ee"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
+checksum = "1a5f392f2f56b2417ea6b74e1e116c6f35df5ab5fce4dc422e277d72ee18ff7b"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -615,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48366d2c42b8d95ef951101bafa28486590f21b7a1e68b6b2d069746557bbe3"
+checksum = "78de3d4ed62e2c90e16be166d0ddfe41944bb5979752703199073acf976083f2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -640,7 +640,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -658,7 +658,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3 0.11.0",
- "syn 2.0.117",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
@@ -676,7 +676,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
+checksum = "39f42ee1ef30d4d3d8b4ea5794937fccfc69e2bb1cd5bcf42d62afc57b049081"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
+checksum = "ee68bc7d713e033eeaaecb8fd13d5d8a41af97226c4388930ad459285b8e9f70"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -759,14 +759,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
+checksum = "dc2cd27809c88c413e5542dbd5a8eff8c12f0086af920e881ae586d3a787d5e5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -856,7 +856,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -962,7 +962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1000,7 +1000,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1086,9 +1086,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -1108,7 +1108,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -1120,7 +1120,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1247,7 +1247,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1288,7 +1288,7 @@ checksum = "99e1aca718ea7b89985790c94aad72d77533063fe00bc497bb79a7c2dae6a661"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1311,14 +1311,36 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -1474,15 +1496,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -1490,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -1541,18 +1563,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "blokli-client"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c49aad21c0d9dac90f52c45894e7f23a7201d0264c07a4546c1df603ca3158"
+checksum = "4ecdfbd15f4ff885b4aaea1630d1e318f15462c85971b0bb3150b228b7792d60"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1571,7 +1593,7 @@ dependencies = [
  "launchdarkly-sdk-transport",
  "parking_lot",
  "rand 0.10.1",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -1625,14 +1647,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1641,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1671,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1698,18 +1720,18 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
 dependencies = [
  "serde_core",
 ]
@@ -1731,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1761,7 +1783,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1826,12 +1848,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -1866,7 +1888,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1885,10 +1907,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmov"
-version = "0.5.3"
+name = "cmake"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -1986,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2183,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -2234,7 +2265,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2265,7 +2296,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 1.0.69",
 ]
 
@@ -2289,7 +2320,7 @@ dependencies = [
  "cynic-codegen",
  "darling 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2323,7 +2354,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2337,7 +2368,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2348,7 +2379,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2359,7 +2390,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2399,7 +2430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2432,7 +2463,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -2466,7 +2496,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2487,7 +2517,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2497,7 +2527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2519,7 +2549,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -2550,20 +2580,20 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2641,14 +2671,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -2713,7 +2743,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2733,7 +2763,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2802,9 +2832,9 @@ dependencies = [
 
 [[package]]
 name = "eventsource-client"
-version = "0.17.4"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4199ae8c124383f00a7af9df684a878186c8081c6c8bf2cac8c29296db3625d"
+checksum = "96df8cfa11d3c8e4e1a48b81c9c600ecbe8c11d1326f41e1524cc4d42f7bf6d9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2964,21 +2994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,6 +3010,12 @@ checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
 dependencies = [
  "futures-core",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3094,7 +3115,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3134,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
  "gloo-timers",
 ]
@@ -3177,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
+checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
  "rustversion",
  "serde_core",
@@ -3216,16 +3237,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -3887,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 
 [[package]]
 name = "gix-transport"
@@ -3939,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
 dependencies = [
  "bstr",
  "fastrand",
@@ -3985,9 +4004,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4018,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4336,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33fb0c32d216e93e58a050edea339bc8ed5bd8fe844bf893b849fc402824412"
+checksum = "2a6e98ff52f636edc8e3d76844831dfd53cd92146488cc721c0f7bb837fd8052"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4376,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4406,13 +4425,13 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "bimap",
  "curve25519-dalek",
  "elliptic-curve",
  "flagset",
- "generic-array 1.4.1",
+ "generic-array 1.4.3",
  "hex",
  "hopr-types",
  "hopr-utils",
@@ -4429,7 +4448,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4446,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.4"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4485,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4504,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4517,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.6.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4547,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4578,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4593,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4612,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4638,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4660,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.29.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4701,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4718,7 +4737,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4738,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.6.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4763,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4796,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4807,26 +4826,27 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e82a6426de74cdef7bbef15f651ce546ab39fc77ef1dc4002247b6bbf034fc"
+checksum = "1d621ab243808540504b0a1e215743d45283e3133e7a4be44d2dd4cb31587a87"
 dependencies = [
  "aes",
  "anyhow",
  "aquamarine",
+ "arrayvec",
  "async-trait",
  "bigdecimal",
  "blake3",
  "chacha20 0.9.1",
  "chrono",
  "cipher 0.4.4",
+ "const-hex",
  "ctr",
  "curve25519-dalek",
  "digest 0.10.7",
  "ed25519-dalek",
  "float-cmp",
- "generic-array 1.4.1",
- "hex",
+ "generic-array 1.4.3",
  "hex-literal",
  "hopr-bindings",
  "k256",
@@ -4863,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4882,7 +4902,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_bytes",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
@@ -4893,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#0757deaf41571cbaeff78b8a6841cec71d77b7a4"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#db2971e7f5de0a8a59105196e2cc19d9a31d3fc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5022,7 +5042,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "syn 2.0.117",
+ "syn 2.0.118",
  "utoipa",
  "uuid",
 ]
@@ -5144,9 +5164,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5193,22 +5213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5225,7 +5229,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5338,12 +5342,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -5470,7 +5468,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5540,7 +5538,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -5597,9 +5595,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -5607,18 +5605,18 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5663,7 +5661,7 @@ dependencies = [
  "quote",
  "rustc_version 0.4.1",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5682,7 +5680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5697,13 +5695,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -5743,9 +5740,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1766b89733097006f3a1388a02849865d6bc98c89273cb622e29fdd209922183"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -5786,9 +5783,9 @@ dependencies = [
 
 [[package]]
 name = "launchdarkly-sdk-transport"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b48629e54c0e45cb102a333271f363eb521e7785d54e5047a5d1c6f2770c765"
+checksum = "a048341aa360a768a7d91ebf6232a574f355ada0724acff2df7c5d8dc1e04c98"
 dependencies = [
  "bytes",
  "futures",
@@ -5801,12 +5798,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -5973,15 +5964,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "hkdf",
  "multihash",
- "quick-protobuf",
+ "prost",
  "rand 0.8.6",
  "serde",
  "sha2 0.10.9",
@@ -6131,7 +6122,7 @@ checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6145,7 +6136,7 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tracing",
 ]
@@ -6222,9 +6213,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "logos"
@@ -6247,7 +6238,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.8.11",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6282,7 +6273,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6293,7 +6284,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6319,20 +6310,20 @@ checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.11"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -6392,9 +6383,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -6424,7 +6415,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6499,23 +6490,6 @@ dependencies = [
  "pin-project",
  "smallvec",
  "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -6633,9 +6607,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -6685,7 +6659,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6772,47 +6746,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -6921,7 +6858,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6949,7 +6886,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7093,7 +7030,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7256,7 +7193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7310,7 +7247,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7343,7 +7280,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "version_check",
  "yansi",
 ]
@@ -7399,7 +7336,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 2.0.18",
  "typify",
  "unicode-ident",
@@ -7420,7 +7357,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "serde_yaml",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7443,7 +7380,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7467,9 +7404,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -7477,22 +7414,22 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -7539,7 +7476,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7548,10 +7485,11 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -7576,7 +7514,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7638,7 +7576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -7773,7 +7711,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7835,38 +7773,27 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
- "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
  "web-sys",
 ]
 
@@ -7878,22 +7805,31 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -7901,7 +7837,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -7976,7 +7912,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-ident",
 ]
 
@@ -8052,7 +7988,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.117",
+ "syn 2.0.118",
  "walkdir",
 ]
 
@@ -8134,6 +8070,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -8145,9 +8082,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -8166,11 +8103,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -8218,7 +8183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
  "cfg-if",
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -8286,7 +8251,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8433,7 +8398,7 @@ checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -8481,7 +8446,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8492,7 +8457,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8528,7 +8493,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8540,7 +8505,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8584,7 +8549,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8675,9 +8640,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3f15d4e239ebe08413eed880e0f9b5af4b40ee0472543320efa91d488e96a7"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
 dependencies = [
  "cc",
  "cfg-if",
@@ -8700,9 +8665,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -8780,9 +8745,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -8795,7 +8760,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8838,9 +8803,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -8916,7 +8881,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8928,7 +8893,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8950,9 +8915,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8968,7 +8933,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8988,7 +8953,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9031,7 +8996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -9062,7 +9027,7 @@ checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9071,7 +9036,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
- "syn 2.0.117",
+ "syn 2.0.118",
  "test-log-core",
 ]
 
@@ -9101,7 +9066,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9112,7 +9077,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9166,12 +9131,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -9183,15 +9147,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -9233,7 +9197,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -9247,24 +9211,14 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "tokio-retry"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f644c762e9d396831ae2f8935c954b0d758c4532e924bead0f666d0c1c8640"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
  "rand 0.10.1",
@@ -9318,9 +9272,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -9357,7 +9311,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -9455,7 +9409,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9534,9 +9488,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typify"
@@ -9563,7 +9517,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -9581,7 +9535,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.117",
+ "syn 2.0.118",
  "typify-impl",
 ]
 
@@ -9650,9 +9604,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -9745,7 +9699,7 @@ checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9791,7 +9745,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -9824,7 +9778,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9832,12 +9786,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
@@ -9920,27 +9868,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9951,9 +9890,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9961,9 +9900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9971,59 +9910,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -10037,18 +9941,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver 1.0.28",
 ]
 
 [[package]]
@@ -10067,9 +9959,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10083,6 +9975,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -10153,7 +10054,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10164,7 +10065,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10397,97 +10298,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -10596,9 +10409,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -10613,28 +10426,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10654,28 +10467,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10708,7 +10521,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.21.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.29.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4721,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.3"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.22.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -4883,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=kauki%2Ffix%2Fp2p%2Fliveness-stream-cache#5d1c330ead1fc242bcd6a7a094c876634c53b5e6"
+source = "git+https://github.com/hoprnet/hoprnet?branch=em%2Ffix_session_being_broken#5a9114aac18bcc56ef801db621a4fdf5c32b5b4a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "kauki/fix/p2p/liveness-stream-cache", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = ["hoprd", "rest-api", "rest-api-client", "localcluster"]
 
+# just kicking build
 [workspace.package]
 rust-version = "1.91"
 authors = ["HOPR Association <tech@hoprnet.org>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 resolver = "2"
 members = ["hoprd", "rest-api", "rest-api-client", "localcluster"]
 
-# just kicking build
 [workspace.package]
 rust-version = "1.91"
 authors = ["HOPR Association <tech@hoprnet.org>"]
@@ -178,3 +177,4 @@ codegen-units = 16
 
 [workspace.metadata.cargo-shear]
 ignored = ["oas3", "humantime-serde", "hopr-api", "hopr-utils"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,4 +177,3 @@ codegen-units = 16
 
 [workspace.metadata.cargo-shear]
 ignored = ["oas3", "humantime-serde", "hopr-api", "hopr-utils"]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "b5ee5069038ad8ef38f917e1b5a37c7331e2fe62", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", branch = "em/fix_session_being_broken", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "d670a6c50517e50e400d40d21e2c11bd078461ac", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "51d0473ddbcc2b9dc97f0c0d956741ef726e1a49", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "64963285334fd26e304b392dc1b590c6e468b761", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "78e7c0408272f7fc7254cbaa5e81996f820dafb5", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "6022f47df2fab161b3a43a8e2a7b4fd661b2d7b2", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/deploy/compose/hoprd/conf/hoprd.cfg.yaml
+++ b/deploy/compose/hoprd/conf/hoprd.cfg.yaml
@@ -50,7 +50,7 @@ strategy:
         restart: {}
         concurrency:
           max_concurrent_actions: 4
-        selector: Default
+        selector: default
 hopr:
   network:
     probe_interval: "3s"

--- a/deploy/compose/hoprd/conf/hoprd.cfg.yaml
+++ b/deploy/compose/hoprd/conf/hoprd.cfg.yaml
@@ -50,6 +50,7 @@ strategy:
         restart: {}
         concurrency:
           max_concurrent_actions: 4
+        selector: Default
 hopr:
   network:
     probe_interval: "3s"

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -139,7 +139,7 @@ fn default_session_establish_max_retries() -> usize {
     HoprLibConfig::default()
         .protocol
         .session
-        .establish_max_retries as usize
+        .establish_max_retries
 }
 
 fn default_probe_recheck_threshold() -> Duration {

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -300,7 +300,7 @@ impl From<UserHoprLibConfig> for HoprLibConfig {
                 },
                 session: SessionGlobalConfig {
                     idle_timeout: value.network.session_idle_timeout,
-                    establish_max_retries: value.network.session_establish_max_retries as usize,
+                    establish_max_retries: value.network.session_establish_max_retries,
                     tag_allocator: TagAllocatorConfig {
                         session: value.network.maximum_sessions as u64,
                         ..Default::default()

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -300,7 +300,7 @@ impl From<UserHoprLibConfig> for HoprLibConfig {
                 },
                 session: SessionGlobalConfig {
                     idle_timeout: value.network.session_idle_timeout,
-                    establish_max_retries: value.network.session_establish_max_retries as u32,
+                    establish_max_retries: value.network.session_establish_max_retries as usize,
                     tag_allocator: TagAllocatorConfig {
                         session: value.network.maximum_sessions as u64,
                         ..Default::default()

--- a/rest-api/src/session.rs
+++ b/rest-api/src/session.rs
@@ -1226,6 +1226,15 @@ mod tests {
             .with_state(state)
     }
 
+    #[test]
+    fn session_id_to_string_round_trips_via_from_hex() {
+        use hopr_lib::api::types::crypto_random::Randomizable;
+        let id = SessionId::random();
+        let hex = id.to_string();
+        let parsed = SessionId::from_hex(&hex).expect("from_hex must accept to_string output");
+        assert_eq!(id, parsed);
+    }
+
     #[tokio::test]
     async fn list_clients_should_return_empty_when_no_sessions() -> anyhow::Result<()> {
         let app = session_router();

--- a/rest-api/src/session.rs
+++ b/rest-api/src/session.rs
@@ -10,7 +10,7 @@ use hopr_lib::api::chain::ChainKeyOperations;
 use hopr_lib::api::node::HasChainApi;
 use hopr_lib::{
     HopRouting, HoprSessionClientConfig,
-    api::types::primitive::{errors::GeneralError, prelude::Address},
+    api::types::primitive::{errors::GeneralError, prelude::Address, traits::ToHex},
     errors::HoprLibError,
     exports::transport::{
         SESSION_MTU, SURB_SIZE, ServiceId, SessionCapabilities, SessionId, SessionTarget,
@@ -1002,7 +1002,7 @@ pub(crate) async fn adjust_session<H: Send + Sync + 'static>(
     Path(session_id): Path<String>,
     Json(args): Json<SessionConfig>,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
-    let session_id = SessionId::from_str(&session_id)
+    let session_id = SessionId::from_hex(&session_id)
         .map_err(|_| (StatusCode::BAD_REQUEST, ApiErrorStatus::InvalidSessionId))?;
 
     if let Some(cfg) = Option::<SurbBalancerConfig>::from(args) {
@@ -1052,7 +1052,7 @@ pub(crate) async fn session_config<H: Send + Sync + 'static>(
     State(state): State<Arc<InternalState<H>>>,
     Path(session_id): Path<String>,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
-    let session_id = SessionId::from_str(&session_id)
+    let session_id = SessionId::from_hex(&session_id)
         .map_err(|_| (StatusCode::BAD_REQUEST, ApiErrorStatus::InvalidSessionId))?;
 
     // Find the configurator for this session across all listeners


### PR DESCRIPTION
fix: broken sessions

Pins hoprnet dependencies to rev `d670a6c5` (hoprnet/hoprnet@d670a6c50517e50e400d40d21e2c11bd078461ac), which includes the session-exit fix from hoprnet/hoprnet#8204.

**Changes in this PR:**
- Bump all hoprnet workspace deps from floating `branch =` to pinned `rev = d670a6c5`
- Fix redundant `as usize` cast in `hoprd/src/config.rs`
- Add missing `selector: Default` field to `deploy/compose/hoprd/conf/hoprd.cfg.yaml` (new required serde field in `ChannelLifecycleConfig`)
- Patch `quinn-proto` 0.11.14→0.11.15 (RUSTSEC-2026-0185, high severity) and `memmap2` 0.9.10→0.9.11 (RUSTSEC-2026-0186, unsound) in `Cargo.lock`
- Remove patched advisories from `.cargo/audit.toml` ignore list
- Add `SessionId` `to_string`/`from_hex` round-trip unit test in `rest-api/src/session.rs`