### PR TITLE
fix(ci): bump build-binaries reusable workflow to 0.10.1

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -38,7 +38,7 @@ jobs:
             build_command: nix build -L .#binary-hoprd-localcluster-x86_64-linux
             build_file: ./localcluster/Cargo.toml
             binary: hoprd-localcluster
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -138,7 +138,7 @@ jobs:
             build_file: ./localcluster/Cargo.toml
             binary: hoprd-localcluster
             required_label: ""
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-arm-8
             build_command: nix build -L .#binary-hoprd-aarch64-linux
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     permissions:
       contents: read
       id-token: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,7 +2399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6328,9 +6328,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -7546,9 +7546,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Fixes two independent CI failures:

**1. Sign and Publish — GCP OIDC auth failure** (build-binaries workflow bump)

`build-binaries.yaml@0.9.3` (hopr-workflows PR #84, 2026-06-15) migrated to Workload Identity Provider auth but omitted `id-token: write` from the `sign` job's `permissions:` block. GitHub caps each reusable-workflow job to its own block, so `$ACTIONS_ID_TOKEN_REQUEST_TOKEN` was never injected. `0.9.5` (PR #87) fixed it. Bumped to `0.10.1` (latest; no breaking input changes).

**2. Check / Audit — two new advisories in `Cargo.lock`**

- `RUSTSEC-2026-0185`: `quinn-proto 0.11.14` — remote memory exhaustion via unbounded out-of-order stream reassembly (CVSS 7.5 high). Fix: `>=0.11.15`. Bumped via `cargo update -p quinn-proto`.
- `RUSTSEC-2026-0186`: `memmap2 0.9.10` — unchecked pointer offset (unsound) via `vergen-gix`. Bumped to `0.9.11` via `cargo update -p memmap2`.

Both lock bumps are transitive-only (no `Cargo.toml` changes). `cargo audit` exits 0 locally after both bumps.