### PR TITLE
feat: Restore deployment on Kubernetes on PR merged

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -57,7 +57,7 @@ jobs:
     name: Docker
     needs: build-binaries
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@ausias/remove-deployment
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@25898d13dab1b3fbf4c33c394e7c581578a2b0d7
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -57,7 +57,7 @@ jobs:
     name: Docker
     needs: build-binaries
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@25898d13dab1b3fbf4c33c394e7c581578a2b0d7
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@25898d13dab1b3fbf4c33c394e7c581578a2b0d7 # build-docker-v3.2.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -57,7 +57,7 @@ jobs:
     name: Docker
     needs: build-binaries
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7263182fc9a2bab22cc5a029929940914eb9748d # setup-gcp-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@ausias/remove-deployment
     permissions:
       contents: read
       pull-requests: write
@@ -82,8 +82,6 @@ jobs:
       docker_image_name: hoprd
       docker_image_format: skopeo
       fail_on_scan_vulnerabilities: ${{ vars.FAIL_ON_SCAN_VULNERABILITIES }}
-      deployment_namespace: core-team
-      deployment_label_selector: app.kubernetes.io/component=node
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   deploy-dev:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -157,7 +157,7 @@ jobs:
   build-docker:
     name: Docker
     needs: build-binaries
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@25898d13dab1b3fbf4c33c394e7c581578a2b0d7
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@25898d13dab1b3fbf4c33c394e7c581578a2b0d7 # build-docker-v3.2.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -157,7 +157,7 @@ jobs:
   build-docker:
     name: Docker
     needs: build-binaries
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7263182fc9a2bab22cc5a029929940914eb9748d # setup-gcp-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@ausias/remove-deployment
     permissions:
       contents: read
       pull-requests: write
@@ -177,8 +177,6 @@ jobs:
       build_file: ./hoprd/Cargo.toml
       docker_image_name: hoprd
       docker_image_format: skopeo
-      deployment_namespace: core-team
-      deployment_label_selector: app.kubernetes.io/component=node
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   docs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -157,7 +157,7 @@ jobs:
   build-docker:
     name: Docker
     needs: build-binaries
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@ausias/remove-deployment # temporary
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@25898d13dab1b3fbf4c33c394e7c581578a2b0d7
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -157,7 +157,7 @@ jobs:
   build-docker:
     name: Docker
     needs: build-binaries
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@ausias/remove-deployment
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@ausias/remove-deployment # temporary
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Now the integration is based on a subscription of the event of a new docker image tag created in Google Artifact registry. Upon receive of this event, we force a deployment using the `keel` operator instead of accessing kubernetes API publicly from the GitHub runner