### PR TITLE
fix: DNS on hoprd nodes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -370,7 +370,6 @@
               name = "hoprd";
               pathsToLink = [
                 "/bin"
-                "/etc"
               ];
               extraContents = [
                 dockerHoprdEntrypoint
@@ -387,8 +386,8 @@
               Cmd = [ "hoprd" ];
               env = [
                 "TMPDIR=/app/.tmp"
-                "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-                "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                 "HOPRD_DEFAULT_SESSION_LISTEN_HOST=auto:0"
               ];
             };
@@ -396,7 +395,6 @@
               name = "hoprd";
               pathsToLink = [
                 "/bin"
-                "/etc"
               ];
               extraContents = [
                 dockerHoprdEntrypoint
@@ -413,8 +411,8 @@
               Cmd = [ "hoprd" ];
               env = [
                 "TMPDIR=/app/.tmp"
-                "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-                "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                 "HOPRD_DEFAULT_SESSION_LISTEN_HOST=auto:0"
               ];
             };
@@ -422,7 +420,6 @@
               name = "hoprd";
               pathsToLink = [
                 "/bin"
-                "/etc"
               ];
               extraContents = [
                 dockerHoprdEntrypoint
@@ -448,8 +445,8 @@
               Cmd = [ "hoprd" ];
               env = [
                 "TMPDIR=/app/.tmp"
-                "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-                "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                 "HOPRD_DEFAULT_SESSION_LISTEN_HOST=auto:0"
                 "_RJEM_MALLOC_CONF=prof:true,prof_active:true,prof_final:true,prof_prefix=/app/.tmp/jeprof,lg_prof_sample:19"
               ];
@@ -458,7 +455,6 @@
               name = "hoprd";
               pathsToLink = [
                 "/bin"
-                "/etc"
               ];
               extraContents = [
                 dockerHoprdEntrypoint
@@ -475,8 +471,8 @@
               Cmd = [ "hoprd" ];
               env = [
                 "TMPDIR=/app/.tmp"
-                "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-                "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                 "HOPRD_DEFAULT_SESSION_LISTEN_HOST=auto:0"
               ];
             };
@@ -484,7 +480,6 @@
               name = "hoprd-localcluster";
               pathsToLink = [
                 "/bin"
-                "/etc"
               ];
               extraContents = [
                 hoprdPackages.binary-hoprd-x86_64-linux


### PR DESCRIPTION
 ### Problem
  Domain targets (e.g. `example.com`) fail to resolve inside the hoprd container; only literal IPs work.

  ### Root cause
  Commit c18bd16 (hoprd extraction) added `pathsToLink = [ "/bin" "/etc" ]` to every `mkDockerImage` call to expose CA certs at
  `/etc/ssl`.

  Linking `/etc` turns the image's `/etc` into a symlink into the read-only Nix store. Docker injects `/etc/resolv.conf` (and
  `/etc/hosts`) at container start via bind-mount — but the target is now read-only and the store path has no `resolv.conf`, so the
  container ends up with no nameserver. `getaddrinfo` name lookups fail; raw-IP targets skip DNS and keep working.

  The pre-extraction hoprnet image used the nix-lib default `pathsToLink = [ "/bin" ]`, leaving `/etc` writable for Docker to
  populate — DNS worked.