### PR TITLE
fix: reported hoprd session via rest API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "4.12.0"
+version = "4.12.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "4.12.0"
+version = "4.12.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/hoprd/src/lib.rs
+++ b/hoprd/src/lib.rs
@@ -289,6 +289,7 @@ async fn init_rest_api(
         async move {
             if let Err(e) = serve_api(RestApiParameters {
                 listener: api_listener,
+                version: env!("CARGO_PKG_VERSION").to_string(),
                 hoprd_cfg: node_cfg_value,
                 cfg: api_cfg,
                 hopr,

--- a/hoprd/src/lib.rs
+++ b/hoprd/src/lib.rs
@@ -285,6 +285,7 @@ async fn init_rest_api(
         async move {
             if let Err(e) = serve_api(RestApiParameters {
                 listener: api_listener,
+                version: env!("CARGO_PKG_VERSION").to_string(),
                 hoprd_cfg: node_cfg_value,
                 cfg: api_cfg,
                 hopr,

--- a/rest-api-client/src/codegen/mod.rs
+++ b/rest-api-client/src/codegen/mod.rs
@@ -2613,7 +2613,7 @@ at least the size of 2 Session packet payloads.*/
 
 API enabling developers to interact with a hoprd node programatically through HTTP REST API.
 
-Version: 4.12.0*/
+Version: 4.12.1*/
 pub struct Client {
     pub(crate) baseurl: String,
     pub(crate) client: reqwest::Client,
@@ -2649,7 +2649,7 @@ impl Client {
 }
 impl ClientInfo<()> for Client {
     fn api_version() -> &'static str {
-        "4.12.0"
+        "4.12.1"
     }
     fn baseurl(&self) -> &str {
         self.baseurl.as_str()

--- a/rest-api/Cargo.toml
+++ b/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "4.12.0"
+version = "4.12.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rest-api/src/account.rs
+++ b/rest-api/src/account.rs
@@ -254,6 +254,7 @@ mod tests {
 
     fn account_router(node: MockChainNode) -> Router {
         let state = Arc::new(crate::InternalState {
+            version: "test-version".to_string(),
             hoprd_cfg: serde_json::Value::Null,
             auth: Arc::new(crate::config::Auth::Token("test".into())),
             hopr: Arc::new(node),
@@ -325,6 +326,7 @@ mod tests {
         let node = MockChainNode::random();
 
         let state = Arc::new(crate::InternalState {
+            version: "test-version".to_string(),
             hoprd_cfg: serde_json::Value::Null,
             auth: Arc::new(crate::config::Auth::Token("test".into())),
             hopr: Arc::new(node),

--- a/rest-api/src/channels.rs
+++ b/rest-api/src/channels.rs
@@ -922,6 +922,7 @@ mod tests {
 
     fn channels_router(node: MockChainNode) -> Router {
         let state = Arc::new(crate::InternalState {
+            version: "test-version".to_string(),
             hoprd_cfg: serde_json::Value::Null,
             auth: Arc::new(crate::config::Auth::Token("test".into())),
             hopr: Arc::new(node),

--- a/rest-api/src/lib.rs
+++ b/rest-api/src/lib.rs
@@ -104,6 +104,7 @@ impl<H> Clone for AppState<H> {
 pub type MessageEncoder = fn(&[u8]) -> Box<[u8]>;
 
 pub(crate) struct InternalState<H> {
+    pub version: String,
     pub hoprd_cfg: serde_json::Value,
     pub auth: Arc<Auth>,
     pub hopr: Arc<H>,
@@ -114,6 +115,7 @@ pub(crate) struct InternalState<H> {
 impl<H> Clone for InternalState<H> {
     fn clone(&self) -> Self {
         Self {
+            version: self.version.clone(),
             hoprd_cfg: self.hoprd_cfg.clone(),
             auth: self.auth.clone(),
             hopr: self.hopr.clone(),
@@ -284,6 +286,7 @@ where
 /// Parameters needed to construct the Rest API via [`serve_api`].
 pub struct RestApiParameters<H> {
     pub listener: TcpListener,
+    pub version: String,
     pub hoprd_cfg: serde_json::Value,
     pub cfg: crate::config::Api,
     pub hopr: Arc<H>,
@@ -301,6 +304,7 @@ where
 {
     let RestApiParameters {
         listener,
+        version,
         hoprd_cfg,
         cfg,
         hopr,
@@ -309,6 +313,7 @@ where
     } = params;
 
     let router = build_api(
+        version,
         hoprd_cfg,
         cfg,
         hopr,
@@ -321,6 +326,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 async fn build_api<H: HoprNode + RestApiSessionFactory>(
+    version: String,
     hoprd_cfg: serde_json::Value,
     cfg: crate::config::Api,
     hopr: Arc<H>,
@@ -335,6 +341,7 @@ where
     let state = AppState { hopr };
     let enable_explicit_path_sessions = cfg.enable_explicit_path_sessions;
     let inner_state = InternalState {
+        version,
         auth: Arc::new(cfg.auth.clone()),
         hoprd_cfg,
         hopr: state.hopr.clone(),
@@ -416,7 +423,7 @@ where
                 .route("/network/connected", get(network::connected::<H>))
                 .route("/network/announced", get(network::announced::<H>))
                 .route("/network/graph", get(network::graph::<H>))
-                .route("/node/version", get(node::version))
+                .route("/node/version", get(node::version::<H>))
                 .route("/node/configuration", get(node::configuration::<H>))
                 .route("/node/info", get(node::info::<H>))
                 .route("/node/status", get(node::status::<H>))

--- a/rest-api/src/network.rs
+++ b/rest-api/src/network.rs
@@ -505,6 +505,7 @@ mod tests {
 
     fn network_router(node: MockChainNode) -> Router {
         let state = Arc::new(crate::InternalState {
+            version: "test-version".to_string(),
             hoprd_cfg: serde_json::Value::Null,
             auth: Arc::new(crate::config::Auth::Token("test".into())),
             hopr: Arc::new(node),

--- a/rest-api/src/node.rs
+++ b/rest-api/src/node.rs
@@ -317,7 +317,7 @@ mod tests {
 
     fn node_router() -> Router {
         let state: Arc<InternalState<NoopNode>> = Arc::new(InternalState {
-            version: "test-version".to_string(),
+        assert_eq!(body["version"], "test-version");
             hoprd_cfg: serde_json::json!({
                 "network": "test-network",
                 "provider": "http://localhost:8545"

--- a/rest-api/src/node.rs
+++ b/rest-api/src/node.rs
@@ -45,8 +45,10 @@ pub(crate) struct NodeVersionResponse {
         ),
         tag = "Node"
     )]
-pub(super) async fn version() -> impl IntoResponse {
-    let version = hopr_lib::constants::APP_VERSION.to_string();
+pub(super) async fn version<H: Send + Sync + 'static>(
+    State(state): State<Arc<InternalState<H>>>,
+) -> impl IntoResponse {
+    let version = state.version.clone();
     (StatusCode::OK, Json(NodeVersionResponse { version })).into_response()
 }
 
@@ -315,6 +317,7 @@ mod tests {
 
     fn node_router() -> Router {
         let state: Arc<InternalState<NoopNode>> = Arc::new(InternalState {
+            version: "test-version".to_string(),
             hoprd_cfg: serde_json::json!({
                 "network": "test-network",
                 "provider": "http://localhost:8545"
@@ -325,7 +328,10 @@ mod tests {
             default_listen_host: "127.0.0.1:0".parse().unwrap(),
         });
         Router::new()
-            .route(&format!("{BASE_PATH}/node/version"), get(version))
+            .route(
+                &format!("{BASE_PATH}/node/version"),
+                get(version::<NoopNode>),
+            )
             .route(
                 &format!("{BASE_PATH}/node/configuration"),
                 get(configuration::<NoopNode>),

--- a/rest-api/src/session.rs
+++ b/rest-api/src/session.rs
@@ -1217,6 +1217,7 @@ mod tests {
 
     fn session_router() -> Router {
         let state: Arc<InternalState<NoopNode>> = Arc::new(InternalState {
+            version: "test-version".to_string(),
             hoprd_cfg: serde_json::json!({}),
             auth: Arc::new(crate::config::Auth::None),
             hopr: Arc::new(NoopNode),

--- a/rest-api/src/tickets.rs
+++ b/rest-api/src/tickets.rs
@@ -328,6 +328,7 @@ mod tests {
 
     fn tickets_router(node: MockChainNode) -> Router {
         let state = Arc::new(crate::InternalState {
+            version: "test-version".to_string(),
             hoprd_cfg: serde_json::Value::Null,
             auth: Arc::new(crate::config::Auth::Token("test".into())),
             hopr: Arc::new(node),


### PR DESCRIPTION
Hoprd is reporting hoprnets version via rest API call. This PR fixes this.