### PR TITLE
feat: Bump hopr-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common 0.1.7",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1656,7 +1656,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1670,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecdfbd15f4ff885b4aaea1630d1e318f15462c85971b0bb3150b228b7792d60"
+checksum = "24c4a03b3618185436fc74269e51c6945a55a3347eb05bde61a5fd3750d28401"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1685,18 +1685,16 @@ dependencies = [
  "futures",
  "futures-time",
  "hex",
- "hopr-types 1.11.2",
+ "hopr-types",
  "http",
  "indexmap 2.14.0",
  "launchdarkly-sdk-transport",
  "parking_lot",
  "rand 0.10.2",
  "reqwest",
- "semver 1.0.28",
  "serde",
  "serde_json",
  "smart-default",
- "strum 0.28.0",
  "thiserror 2.0.18",
  "tracing",
  "url",
@@ -1818,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -2320,7 +2318,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2348,7 +2346,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2599,7 +2597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2738,7 +2736,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -2915,7 +2913,7 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
- "generic-array 0.14.7",
+ "generic-array",
  "group 0.13.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -3458,17 +3456,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
-]
-
-[[package]]
-name = "generic-array"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
-dependencies = [
- "rustversion",
- "typenum",
  "zeroize",
 ]
 
@@ -4661,7 +4648,7 @@ dependencies = [
  "chrono",
  "futures",
  "futures-concurrency",
- "hopr-types 2.0.0",
+ "hopr-types",
  "libp2p-identity",
  "multiaddr",
  "serde",
@@ -4691,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4722,12 +4709,12 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "bimap",
  "const-hex",
  "flagset",
- "hopr-types 2.0.0",
+ "hopr-types",
  "hopr-utils",
  "serde",
  "serde_bytes",
@@ -4740,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4757,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4796,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4815,10 +4802,10 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "hopr-crypto-packet",
- "hopr-types 2.0.0",
+ "hopr-types",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -4828,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4858,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4871,7 +4858,7 @@ dependencies = [
  "futures-time",
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
- "hopr-types 2.0.0",
+ "hopr-types",
  "hopr-utils",
  "lazy_static",
  "parking_lot",
@@ -4889,7 +4876,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4904,7 +4891,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -4923,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.19.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4949,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4971,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5013,11 +5000,11 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "futures",
  "futures-timer",
- "hopr-types 2.0.0",
+ "hopr-types",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -5030,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5052,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5078,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5110,60 +5097,13 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "hopr-protocol-app",
  "serde",
  "smart-default",
  "thiserror 2.0.18",
  "validator",
-]
-
-[[package]]
-name = "hopr-types"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe8de530de5d86e896cc67ffa9b57496626d381112442800b18cd7b41e440c4"
-dependencies = [
- "aes 0.9.1",
- "aquamarine",
- "arrayvec",
- "async-trait",
- "babyjubjub-ec",
- "bigdecimal",
- "blake3",
- "chacha20 0.10.1",
- "chrono",
- "cipher 0.5.2",
- "const-hex",
- "ctr 0.10.1",
- "curve25519-dalek 5.0.0",
- "digest 0.11.3",
- "ed25519-dalek 3.0.0",
- "float-cmp",
- "generic-array 1.4.3",
- "hash2curve",
- "hex-literal",
- "k256 0.14.0",
- "lazy_static",
- "libp2p-identity",
- "multiaddr",
- "num_enum",
- "poly1305 0.9.1",
- "primitive-types 0.14.0",
- "rand 0.10.2",
- "rayon",
- "regex",
- "secp256k1 0.31.1",
- "sha2 0.11.0",
- "sha3 0.12.0",
- "smart-default",
- "strum 0.28.0",
- "subtle",
- "thiserror 2.0.18",
- "tracing",
- "typenum",
- "zeroize",
 ]
 
 [[package]]
@@ -5229,7 +5169,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils"
 version = "0.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -5238,7 +5178,7 @@ dependencies = [
  "futures",
  "futures-time",
  "hickory-resolver 0.26.1",
- "hopr-types 2.0.0",
+ "hopr-types",
  "indexmap 2.14.0",
  "lazy_static",
  "libc",
@@ -5260,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=0ffc8661a098eec704e009c55687cb14619109a7#0ffc8661a098eec704e009c55687cb14619109a7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=d601edc42c2c4b44416274cd6f32ae6f9c721ba1#d601edc42c2c4b44416274cd6f32ae6f9c721ba1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5871,7 +5811,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -6141,9 +6081,9 @@ dependencies = [
 
 [[package]]
 name = "launchdarkly-sdk-transport"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a048341aa360a768a7d91ebf6232a574f355ada0724acff2df7c5d8dc1e04c98"
+checksum = "032d66802c461d7254ed1de887be6ca98ebbe126867d9a60c754baae81c4d10d"
 dependencies = [
  "bytes",
  "futures",
@@ -8680,7 +8620,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
  "der 0.7.10",
- "generic-array 0.14.7",
+ "generic-array",
  "pkcs8 0.10.2",
  "serdect 0.2.0",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "0ffc8661a098eec704e009c55687cb14619109a7", default-features = false }
+hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1" }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "d601edc42c2c4b44416274cd6f32ae6f9c721ba1", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/hoprd/src/lib.rs
+++ b/hoprd/src/lib.rs
@@ -116,10 +116,6 @@ pub async fn main_inner(cfg: HoprdConfig, hopr_keys: HoprKeys) -> anyhow::Result
                 timeout: std::time::Duration::from_secs(30),
                 stream_reconnect_timeout: std::time::Duration::from_secs(30),
                 subscription_stream_restart_delay: Some(std::time::Duration::from_secs(1)),
-                // Allow local clusters to skip the blokli version compatibility check:
-                // some dev images (e.g. bloklid-anvil) do index Safe events but don't
-                // yet advertise the IndexesSafeEvents feature flag in their API response.
-                auto_compatibility_check: std::env::var("HOPR_BLOKLI_NO_COMPAT_CHECK").is_err(),
                 ..Default::default()
             },
         ),

--- a/localcluster/src/client_helper.rs
+++ b/localcluster/src/client_helper.rs
@@ -276,7 +276,6 @@ pub async fn start_nodes(config: &NodeStartConfig<'_>) -> Result<Vec<NodeProcess
                 "HOPR_TX_TIMEOUT_MULTIPLIER",
                 crate::identity::DEFAULT_TX_TIMEOUT_MULTIPLIER.to_string(),
             )
-            .env("HOPR_BLOKLI_NO_COMPAT_CHECK", "1")
             .stdout(Stdio::from(log_file))
             .stderr(Stdio::from(log_err));
 

--- a/localcluster/src/identity.rs
+++ b/localcluster/src/identity.rs
@@ -189,13 +189,8 @@ pub async fn generate(config: &GenerationConfig) -> anyhow::Result<GenerationOut
     let home_path = &config.config_home;
     let private_key = hex::decode(&config.private_key).context("invalid private key")?;
 
-    let blokli_client = BlokliClient::new(
-        config.blokli_url.parse()?,
-        BlokliClientConfig {
-            auto_compatibility_check: false,
-            ..Default::default()
-        },
-    );
+    let blokli_client =
+        BlokliClient::new(config.blokli_url.parse()?, BlokliClientConfig::default());
     let status = blokli_client.query_health().await?;
     if !status.eq_ignore_ascii_case("ok") {
         return Err(anyhow::anyhow!("Blokli is not usable: {status}"));


### PR DESCRIPTION
Includes blokli-client bump to v0.30.0, which required changes to be compatible.