### PR TITLE
feat: include ticket-inspector binary in Docker images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4967,6 +4967,8 @@ dependencies = [
  "parking_lot",
  "postcard",
  "redb",
+ "serde",
+ "serde_json",
  "strum 0.28.0",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,11 @@ hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c6516702136
 hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
 hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
 hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false, features = [
+  "redb",
+  "cli",
+  "serde",
+] }
 hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
 hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
 

--- a/flake.lock
+++ b/flake.lock
@@ -16,7 +16,39 @@
         "type": "github"
       }
     },
+    "crane_2": {
+      "locked": {
+        "lastModified": 1768319649,
+        "narHash": "sha256-VFkNyxHxkqGp8gf8kfFMW1j6XeBy609kv6TE9uF/0Js=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "4b6527687cfd20da3c2ef8287e01b74c2d6c705b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.23.0",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -52,7 +84,43 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "hoprnet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-root": {
+      "locked": {
+        "lastModified": 1723604017,
+        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "flake-root_2": {
       "locked": {
         "lastModified": 1723604017,
         "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
@@ -70,6 +138,24 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -109,6 +195,32 @@
         "type": "github"
       }
     },
+    "foundry_2": {
+      "inputs": {
+        "flake-utils": [
+          "hoprnet",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "hoprnet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747840881,
+        "narHash": "sha256-5qXoSkkfz5cFRVIQ/p/mNKaJjRmhaKgQymHUfziWj1g=",
+        "owner": "hoprnet",
+        "repo": "foundry.nix",
+        "rev": "f6de4e0a8d66a4bbe124fbf48807e4d7ef1412b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hoprnet",
+        "ref": "tb/202505-add-xz",
+        "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -130,7 +242,139 @@
         "type": "github"
       }
     },
+    "hopli": {
+      "inputs": {
+        "flake-parts": [
+          "hoprnet",
+          "flake-parts"
+        ],
+        "flake-root": [
+          "hoprnet",
+          "flake-root"
+        ],
+        "flake-utils": [
+          "hoprnet",
+          "flake-utils"
+        ],
+        "foundry": [
+          "hoprnet",
+          "foundry"
+        ],
+        "nix-lib": [
+          "hoprnet",
+          "nix-lib"
+        ],
+        "nixpkgs": [
+          "hoprnet",
+          "nixpkgs"
+        ],
+        "nixpkgs-unstable": [
+          "hoprnet",
+          "nixpkgs-unstable"
+        ],
+        "pre-commit": [
+          "hoprnet",
+          "pre-commit"
+        ],
+        "rust-overlay": [
+          "hoprnet",
+          "rust-overlay"
+        ],
+        "treefmt-nix": [
+          "hoprnet",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784025774,
+        "narHash": "sha256-wcC/7oAySSZ1HM8Lm+EVk1naKtt9a2k98jKIVIGeYq4=",
+        "owner": "hoprnet",
+        "repo": "hopli",
+        "rev": "567a9577e2bc224314b536bf574a7211ff8daa92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hoprnet",
+        "repo": "hopli",
+        "type": "github"
+      }
+    },
+    "hoprnet": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-parts": "flake-parts_2",
+        "flake-root": "flake-root_2",
+        "flake-utils": "flake-utils_2",
+        "foundry": "foundry_2",
+        "hopli": "hopli",
+        "nix-lib": "nix-lib",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "pre-commit": "pre-commit",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1785173824,
+        "narHash": "sha256-223xKF1DwQ6kbuZQgZ5uAwTarTK+NuS2TIdZcw2ojTI=",
+        "owner": "hoprnet",
+        "repo": "hoprnet",
+        "rev": "847d1c65167021367fe5b8a164cb707ccf7317d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hoprnet",
+        "repo": "hoprnet",
+        "type": "github"
+      }
+    },
     "nix-lib": {
+      "inputs": {
+        "crane": [
+          "hoprnet",
+          "crane"
+        ],
+        "flake-parts": [
+          "hoprnet",
+          "flake-parts"
+        ],
+        "flake-utils": [
+          "hoprnet",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "hoprnet",
+          "nixpkgs"
+        ],
+        "nixpkgs-unstable": [
+          "hoprnet",
+          "nixpkgs-unstable"
+        ],
+        "rust-overlay": [
+          "hoprnet",
+          "rust-overlay"
+        ],
+        "treefmt-nix": [
+          "hoprnet",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774276825,
+        "narHash": "sha256-IV3mmWG5VvrP823sn5MBprMOe3ONKdMr9mc6LzFgGYM=",
+        "owner": "hoprnet",
+        "repo": "nix-lib",
+        "rev": "42a9dba36c23f39301cc0d8b1c13be871e1964c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hoprnet",
+        "ref": "v1.1.0",
+        "repo": "nix-lib",
+        "type": "github"
+      }
+    },
+    "nix-lib_2": {
       "inputs": {
         "crane": [
           "crane"
@@ -171,21 +415,37 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776558128,
-        "narHash": "sha256-1ileb9AoG+Qp9jXz0TD8rcugikbwJE3mX7TjEEyXU2U=",
+        "lastModified": 1784089646,
+        "narHash": "sha256-A7CVK4jPobQx9/TaEpQRDOpC2IhbhRJpQiWqMrISLzg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb1587379964beaf15e77681f1a4989f3674b184",
+        "rev": "3efa7593820af4ca33a199f8925bf258756af112",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1784098817,
+        "narHash": "sha256-W4biCHkHftdPKhPR0XL+45OMExkfsEfQR809DmsEcKI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "01357ecad648552d77163f2efeb65c7cc784c42a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_2": {
       "locked": {
         "lastModified": 1777281232,
         "narHash": "sha256-B6mjV4fAO+blAS3LOGHhqzeygbpBSk2aKVvjN/zHaIc=",
@@ -201,9 +461,47 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1776558128,
+        "narHash": "sha256-1ileb9AoG+Qp9jXz0TD8rcugikbwJE3mX7TjEEyXU2U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bb1587379964beaf15e77681f1a4989f3674b184",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "pre-commit": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "hoprnet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -230,15 +528,38 @@
         "flake-root": "flake-root",
         "flake-utils": "flake-utils",
         "foundry": "foundry",
-        "nix-lib": "nix-lib",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "pre-commit": "pre-commit",
-        "rust-overlay": "rust-overlay",
-        "treefmt-nix": "treefmt-nix"
+        "hoprnet": "hoprnet",
+        "nix-lib": "nix-lib_2",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "pre-commit": "pre-commit_2",
+        "rust-overlay": "rust-overlay_2",
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "hoprnet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784091390,
+        "narHash": "sha256-aILAwrBQPhKldL98N8lmsbfst3OPtbMM4vT2VXn40/Y=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a7887636a3959168bd1ba7ef24a8a70b168dcb56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "ref": "master",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -274,7 +595,43 @@
         "type": "github"
       }
     },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hoprnet",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -160,6 +160,18 @@
               pkgs.stdenv.cc.cc.lib
             ];
           };
+          ticketInspectorBuildArgs = projectBuildArgs // {
+            cargoExtraArgs = "-p hopr-ticket-manager --bin ticket-inspector";
+          };
+
+          # Crane only auto-installs binaries from the crate referenced by cargoToml.
+          # For git-dep binaries we must copy them manually after build.
+          installTicketInspector = old: {
+            postInstall = (if old ? postInstall && old.postInstall != null then old.postInstall else "") + ''
+              mkdir -p "$out/bin"
+              find target -maxdepth 4 -executable -type f -name "ticket-inspector" -exec cp {} "$out/bin/" \;
+            '';
+          };
           localclusterBuildArgs = {
             inherit src depsSrc rev;
             cargoExtraArgs = "-p hoprd-localcluster";
@@ -247,6 +259,10 @@
               cargoExtraArgs = "-p hoprd --bin hoprd-cfg";
               cargoToml = ./hoprd/Cargo.toml;
             };
+
+            binary-ticket-inspector = (rust-builder-local.callPackage nixLib.mkRustPackage ticketInspectorBuildArgs).overrideAttrs installTicketInspector;
+            binary-ticket-inspector-x86_64-linux = (rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage ticketInspectorBuildArgs).overrideAttrs installTicketInspector;
+            binary-ticket-inspector-aarch64-linux = (rust-builder-aarch64-linux.callPackage nixLib.mkRustPackage ticketInspectorBuildArgs).overrideAttrs installTicketInspector;
 
             test-unit =
               (fixUtoipaEmbedPaths (
@@ -375,6 +391,7 @@
                 dockerHoprdEntrypoint
                 pkgs.tini
                 hoprdPackages.binary-hoprd-x86_64-linux
+                hoprdPackages.binary-ticket-inspector-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -400,6 +417,7 @@
                 dockerHoprdEntrypoint
                 pkgs.tini
                 hoprdPackages.binary-hoprd-dev-x86_64-linux
+                hoprdPackages.binary-ticket-inspector-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -460,6 +478,7 @@
                 dockerHoprdEntrypoint
                 pkgs.tini
                 hoprdPackages.binary-hoprd-aarch64-linux
+                hoprdPackages.binary-ticket-inspector-aarch64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -484,6 +503,7 @@
               extraContents = [
                 hoprdPackages.binary-hoprd-x86_64-linux
                 hoprdPackages.binary-hoprd-localcluster-x86_64-linux
+                hoprdPackages.binary-ticket-inspector-x86_64-linux
                 pkgs.cacert
               ];
               Entrypoint = [ "hoprd-localcluster" ];

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
     rust-overlay.url = "github:oxalica/rust-overlay/master";
     crane.url = "github:ipetkov/crane/v0.23.0";
     nix-lib.url = "github:hoprnet/nix-lib/v1.1.0";
+    hoprnet.url = "github:hoprnet/hoprnet";
     foundry.url = "github:hoprnet/foundry.nix/tb/202505-add-xz";
     pre-commit.url = "github:cachix/git-hooks.nix";
     treefmt-nix.url = "github:numtide/treefmt-nix";
@@ -39,6 +40,7 @@
       rust-overlay,
       crane,
       nix-lib,
+      hoprnet,
       foundry,
       pre-commit,
       ...
@@ -160,18 +162,6 @@
               pkgs.stdenv.cc.cc.lib
             ];
           };
-          ticketInspectorBuildArgs = projectBuildArgs // {
-            cargoExtraArgs = "-p hopr-ticket-manager --bin ticket-inspector";
-          };
-
-          # Crane only auto-installs binaries from the crate referenced by cargoToml.
-          # For git-dep binaries we must copy them manually after build.
-          installTicketInspector = old: {
-            postInstall = (if old ? postInstall && old.postInstall != null then old.postInstall else "") + ''
-              mkdir -p "$out/bin"
-              find target -maxdepth 4 -executable -type f -name "ticket-inspector" -exec cp {} "$out/bin/" \;
-            '';
-          };
           localclusterBuildArgs = {
             inherit src depsSrc rev;
             cargoExtraArgs = "-p hoprd-localcluster";
@@ -259,10 +249,6 @@
               cargoExtraArgs = "-p hoprd --bin hoprd-cfg";
               cargoToml = ./hoprd/Cargo.toml;
             };
-
-            binary-ticket-inspector = (rust-builder-local.callPackage nixLib.mkRustPackage ticketInspectorBuildArgs).overrideAttrs installTicketInspector;
-            binary-ticket-inspector-x86_64-linux = (rust-builder-x86_64-linux.callPackage nixLib.mkRustPackage ticketInspectorBuildArgs).overrideAttrs installTicketInspector;
-            binary-ticket-inspector-aarch64-linux = (rust-builder-aarch64-linux.callPackage nixLib.mkRustPackage ticketInspectorBuildArgs).overrideAttrs installTicketInspector;
 
             test-unit =
               (fixUtoipaEmbedPaths (
@@ -391,7 +377,7 @@
                 dockerHoprdEntrypoint
                 pkgs.tini
                 hoprdPackages.binary-hoprd-x86_64-linux
-                hoprdPackages.binary-ticket-inspector-x86_64-linux
+                hoprnet.packages.${system}.binary-ticket-inspector-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -417,7 +403,7 @@
                 dockerHoprdEntrypoint
                 pkgs.tini
                 hoprdPackages.binary-hoprd-dev-x86_64-linux
-                hoprdPackages.binary-ticket-inspector-x86_64-linux
+                hoprnet.packages.${system}.binary-ticket-inspector-x86_64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -478,7 +464,7 @@
                 dockerHoprdEntrypoint
                 pkgs.tini
                 hoprdPackages.binary-hoprd-aarch64-linux
-                hoprdPackages.binary-ticket-inspector-aarch64-linux
+                hoprnet.packages.${system}.binary-ticket-inspector-aarch64-linux
                 pkgs.cacert
                 pkgs.curl
               ];
@@ -503,7 +489,7 @@
               extraContents = [
                 hoprdPackages.binary-hoprd-x86_64-linux
                 hoprdPackages.binary-hoprd-localcluster-x86_64-linux
-                hoprdPackages.binary-ticket-inspector-x86_64-linux
+                hoprnet.packages.${system}.binary-ticket-inspector-x86_64-linux
                 pkgs.cacert
               ];
               Entrypoint = [ "hoprd-localcluster" ];


### PR DESCRIPTION
- Adds the `ticket-inspector` diagnostic CLI tool to all Docker images built by the flake (`docker-hoprd-x86_64-linux`, `docker-hoprd-dev-x86_64-linux`, `docker-hoprd-aarch64-linux`, `docker-hoprd-localcluster-x86_64-linux`)
- The binary is now available alongside `hoprd` in containers for inspecting the HOPR tickets database

## Changes

- **`Cargo.toml`**: Enabled `redb`, `cli`, `serde` features on the `hopr-ticket-manager` workspace dependency so Crane can build the `ticket-inspector` binary target
- **`flake.nix`**: Added `ticketInspectorBuildArgs` derivation, a `installTicketInspector` helper with `postInstall` hook (Crane only auto-installs binaries from the `cargoToml`-referenced crate), and included the binary in all four Docker image `extraContents`

## Test plan

- `nix build .#binary-ticket-inspector-x86_64-linux` — builds successfully
- `nix build .#docker-hoprd-x86_64-linux` — Docker image builds successfully
- `docker run --rm hoprd find /bin -name ticket-inspector` — binary present in image
- `docker run --rm hoprd ticket-inspector --help` — runs and displays help text correctly