### PR TITLE
fix: Fix docker build on arm systems using cache

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -73,7 +73,7 @@ jobs:
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-24.04-4",
+            "runner": "depot-ubuntu-24.04-arm-4",
             "architecture": "aarch64-linux",
             "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }


### PR DESCRIPTION
Reduces the build time on aarch64-linux for docker.
Should reduce merge.yaml pipeline by 9 minutes