### PR TITLE
fix: Fixes docker build on aarm64 by updating nix-lib

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -172,6 +172,11 @@ jobs:
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux",
             "build_debug_command": "nix build -L .#docker-hoprd-dev-x86_64-linux"
+          },
+          {
+            "runner": "depot-ubuntu-24.04-arm-4",
+            "architecture": "aarch64-linux",
+            "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }
         ]
       build_file: ./hoprd/Cargo.toml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -172,11 +172,6 @@ jobs:
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux",
             "build_debug_command": "nix build -L .#docker-hoprd-dev-x86_64-linux"
-          },
-          {
-            "runner": "depot-ubuntu-24.04-arm-4",
-            "architecture": "aarch64-linux",
-            "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }
         ]
       build_file: ./hoprd/Cargo.toml

--- a/flake.lock
+++ b/flake.lock
@@ -134,16 +134,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785224583,
+        "lastModified": 1785227162,
         "narHash": "sha256-ASCxte061GyYy3S9+1oIAB4IVAA4ScdRt33IVCz3BQc=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "a22fb3d05ee6ab6ae3c99f17d2ceb1bd13d3df8c",
+        "rev": "ee06545d444a446778d9d6637179c46a807b08f5",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
-        "ref": "ausias/build-docker-aarch64",
+        "ref": "v1.2.1",
         "repo": "nix-lib",
         "type": "github"
       }
@@ -166,11 +166,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785224950,
-        "narHash": "sha256-lk+2su6nxVsUySq4DKlWwILr7PQrGGG2lMQZOdFut9I=",
+        "lastModified": 1785227066,
+        "narHash": "sha256-HmKXwBDQEe85O6nwMSdn8QheXqBOyPhcs2TFtXbBf1c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "788fc8edc286b1fd742c69e5382d298eac619d22",
+        "rev": "d10ce5fd5962dc368e2c4cc8df6c9c645fe8dc68",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -109,27 +109,6 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "pre-commit",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nix-lib": {
       "inputs": {
         "crane": [
@@ -155,27 +134,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1774276825,
-        "narHash": "sha256-IV3mmWG5VvrP823sn5MBprMOe3ONKdMr9mc6LzFgGYM=",
+        "lastModified": 1785224583,
+        "narHash": "sha256-ASCxte061GyYy3S9+1oIAB4IVAA4ScdRt33IVCz3BQc=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "42a9dba36c23f39301cc0d8b1c13be871e1964c6",
+        "rev": "a22fb3d05ee6ab6ae3c99f17d2ceb1bd13d3df8c",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
-        "ref": "v1.1.0",
+        "ref": "ausias/build-docker-aarch64",
         "repo": "nix-lib",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776558128,
-        "narHash": "sha256-1ileb9AoG+Qp9jXz0TD8rcugikbwJE3mX7TjEEyXU2U=",
+        "lastModified": 1783375776,
+        "narHash": "sha256-pg6hLjDeAWaUOzh2JM2Cw0BwYpGtOyNr6A4FBwP9Ymo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb1587379964beaf15e77681f1a4989f3674b184",
+        "rev": "cd648d6ea62bc0ffba91e61fcfe5e33c1e2004b1",
         "type": "github"
       },
       "original": {
@@ -187,11 +166,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777281232,
-        "narHash": "sha256-B6mjV4fAO+blAS3LOGHhqzeygbpBSk2aKVvjN/zHaIc=",
+        "lastModified": 1785224950,
+        "narHash": "sha256-lk+2su6nxVsUySq4DKlWwILr7PQrGGG2lMQZOdFut9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbbe0d8096045b5b7b7edc9e7c937bcdd2baed22",
+        "rev": "788fc8edc286b1fd742c69e5382d298eac619d22",
         "type": "github"
       },
       "original": {
@@ -204,17 +183,16 @@
     "pre-commit": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -245,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781147846,
-        "narHash": "sha256-hBdiQYd40xRtBWBiXHUxuQYWmJBiK19YO1FiYgrmEo0=",
+        "lastModified": 1785216007,
+        "narHash": "sha256-KrGilCiFVxEQOaBD3TODhklZzE7uICQvqsBWgycIABA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "107c334f141854f563f8adf1db781dc453d92639",
+        "rev": "8ec8a5a41f8d8244e672829c9cd705416139d3f0",
         "type": "github"
       },
       "original": {
@@ -281,11 +259,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/master";
     rust-overlay.url = "github:oxalica/rust-overlay/master";
     crane.url = "github:ipetkov/crane/v0.23.0";
-    nix-lib.url = "github:hoprnet/nix-lib/v1.1.0";
+    nix-lib.url = "github:hoprnet/nix-lib/ausias/build-docker-aarch64";
     foundry.url = "github:hoprnet/foundry.nix/tb/202505-add-xz";
     pre-commit.url = "github:cachix/git-hooks.nix";
     treefmt-nix.url = "github:numtide/treefmt-nix";
@@ -453,6 +453,12 @@
             };
             docker-hoprd-aarch64-linux = nixLib.mkDockerImage {
               name = "hoprd";
+              # nix-lib's mkDockerImage defaults to a hardcoded x86_64-linux
+              # nixpkgs import for the image-building tooling (base.json,
+              # layers.json, etc). On a native aarch64-linux runner that
+              # tooling can't be built or substituted, so pass the ambient
+              # (already aarch64-native) pkgs explicitly.
+              pkgsLinux = if pkgs.stdenv.isLinux then pkgs else null;
               pathsToLink = [
                 "/bin"
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/master";
     rust-overlay.url = "github:oxalica/rust-overlay/master";
     crane.url = "github:ipetkov/crane/v0.23.0";
-    nix-lib.url = "github:hoprnet/nix-lib/ausias/build-docker-aarch64";
+    nix-lib.url = "github:hoprnet/nix-lib/v1.2.1";
     foundry.url = "github:hoprnet/foundry.nix/tb/202505-add-xz";
     pre-commit.url = "github:cachix/git-hooks.nix";
     treefmt-nix.url = "github:numtide/treefmt-nix";

--- a/flake.nix
+++ b/flake.nix
@@ -455,9 +455,9 @@
               name = "hoprd";
               # nix-lib's mkDockerImage defaults to a hardcoded x86_64-linux
               # nixpkgs import for the image-building tooling (base.json,
-              # layers.json, etc). On a native aarch64-linux runner that
-              # tooling can't be built or substituted, so pass the ambient
-              # (already aarch64-native) pkgs explicitly.
+              # layers.json, etc). Building that tooling for x86_64-linux can
+              # fail on non-x86_64 Linux runners, so pass the ambient pkgs
+              # (native for the current runner) explicitly.
               pkgsLinux = if pkgs.stdenv.isLinux then pkgs else null;
               pathsToLink = [
                 "/bin"


### PR DESCRIPTION
Updates to latest nix-lib revision which contains the fix to build docker images in arm64 runners