### PR TITLE
chore(hoprd): bump version from 4.0.3-rc.4 to 4.0.3 to prepare a release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd"
-version = "4.0.3-rc.4"
+version = "4.0.3"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/hoprd/Cargo.toml
+++ b/hoprd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd"
-version = "4.0.3-rc.4"
+version = "4.0.3"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
This pull request updates the version number of the `hoprd` package. The version is incremented from `4.0.3-rc.4` (a release candidate) to the stable release `4.0.3`.

- Versioning:
  * Updated the `version` field in `Cargo.toml` from `4.0.3-rc.4` to `4.0.3`, marking the transition from release candidate to official stable release.