### PR TITLE
feat(deps): bump hoprnet to c4ace897 (unbounded loopback + ordered decode)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5122,8 +5122,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.33.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+version = "0.33.6"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5155,6 +5155,7 @@ dependencies = [
  "proc-macro-regex",
  "rand 0.10.2",
  "rand_distr",
+ "rust-stream-ext-concurrent",
  "serde",
  "smart-default",
  "strum",
@@ -5167,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5184,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5206,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5232,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5264,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -5368,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8589,6 +8590,16 @@ checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
  "sha2 0.11.0",
  "walkdir",
+]
+
+[[package]]
+name = "rust-stream-ext-concurrent"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b7b0b486f2712aa8fa4a7b21303d79c60ceca3b11a3e9d82eb7c650bc9c4ff"
+dependencies = [
+ "futures",
+ "pin-project",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.33.7"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.33.7"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a0706fdf98a483e9870c18b3f836e66ffd41ef4c#a0706fdf98a483e9870c18b3f836e66ffd41ef4c"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a606efb226da9b12a61e2a9789b6377aa9477296#a606efb226da9b12a61e2a9789b6377aa9477296"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5122,8 +5122,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.33.6"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+version = "0.33.7"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a3e186102ad5312abe0eff115b429348929eb810#a3e186102ad5312abe0eff115b429348929eb810"
+source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5505,7 +5505,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-localcluster"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5122,8 +5122,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.33.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+version = "0.33.5"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5155,7 +5155,6 @@ dependencies = [
  "proc-macro-regex",
  "rand 0.10.2",
  "rand_distr",
- "rust-stream-ext-concurrent",
  "serde",
  "smart-default",
  "strum",
@@ -5168,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5185,7 +5184,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5207,7 +5206,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5265,7 +5264,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -5369,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
+source = "git+https://github.com/hoprnet/hoprnet?rev=1373c840e3c38844b17428c147ec1dbf190e90b1#1373c840e3c38844b17428c147ec1dbf190e90b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8590,16 +8589,6 @@ checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
  "sha2 0.11.0",
  "walkdir",
-]
-
-[[package]]
-name = "rust-stream-ext-concurrent"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b7b0b486f2712aa8fa4a7b21303d79c60ceca3b11a3e9d82eb7c650bc9c4ff"
-dependencies = [
- "futures",
- "pin-project",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5122,8 +5122,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.33.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+version = "0.33.4"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
+source = "git+https://github.com/hoprnet/hoprnet?rev=72ff16432b37a0d2adab03f18449ef0f0ccfbe99#72ff16432b37a0d2adab03f18449ef0f0ccfbe99"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -131,13 +131,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.34"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
+checksum = "c36ddb69f5e41407e7a93aead3480f7c8ff076e73d01a951ae8f7ea4542c1ca0"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum 0.27.2",
+ "phf",
 ]
 
 [[package]]
@@ -159,12 +159,12 @@ dependencies = [
  "either",
  "k256 0.13.4",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -200,15 +200,15 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-core"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
+checksum = "e8421a5ee9019b6d89f92935d0f8facd9f6ca088b41d7cc47244a02ccde4545f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
+checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -230,7 +230,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -243,7 +243,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -269,21 +269,21 @@ dependencies = [
  "borsh",
  "k256 0.13.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17201e6cbb4efbb1e510b0746839cd743a5cec3fcfb4673ea2342bd657341c93"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
+checksum = "6cee30dd4c2f4b23f434fdf675e7bf9681b86768141277266c6f548ef25cba0a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -374,7 +374,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -401,7 +401,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -431,25 +431,26 @@ dependencies = [
  "alloy-signer-local",
  "k256 0.13.4",
  "libc",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more",
+ "fixed-cache",
  "foldhash 0.2.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -458,7 +459,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -501,7 +502,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -510,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -521,13 +522,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -610,7 +611,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -636,7 +637,7 @@ dependencies = [
  "either",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -651,48 +652,48 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256 0.13.4",
- "rand 0.8.6",
- "thiserror 2.0.18",
+ "rand 0.8.7",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
+checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
+checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "sha3 0.11.0",
- "syn 2.0.118",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
+checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -702,25 +703,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.118",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
+checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
 dependencies = [
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
+checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -736,14 +737,14 @@ checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
- "base64 0.22.1",
+ "base64",
  "derive_more",
  "futures",
  "futures-utils-wasm",
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
@@ -779,7 +780,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -792,7 +793,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -867,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "aquamarine"
@@ -882,7 +883,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -896,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -994,6 +995,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,7 +1038,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1058,7 +1086,20 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1103,11 +1144,24 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
 ]
 
 [[package]]
@@ -1118,7 +1172,18 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1128,7 +1193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1138,7 +1203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1148,7 +1213,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1178,10 +1253,10 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -1193,7 +1268,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -1205,7 +1280,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1214,7 +1289,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -1245,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1279,7 +1354,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -1321,18 +1396,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1373,7 +1448,7 @@ checksum = "99e1aca718ea7b89985790c94aad72d77533063fe00bc497bb79a7c2dae6a661"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1382,7 +1457,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http",
  "log",
  "url",
@@ -1396,7 +1471,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1407,9 +1482,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1417,14 +1492,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1550,10 +1626,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.21.7"
+name = "base45"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base64"
@@ -1593,41 +1669,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
 dependencies = [
- "bit-vec",
+ "bitcoin-internals",
+ "hex-conservative 1.2.0",
+ "serde",
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.8.0"
+name = "bitcoin-internals"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.100"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -1710,7 +1797,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
@@ -1727,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
 dependencies = [
  "cc",
  "glob",
@@ -1739,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -1750,15 +1837,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1793,13 +1880,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1840,18 +1927,18 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "c-kzg"
-version = "2.1.7"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
 dependencies = [
  "blst",
  "cc",
@@ -1864,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1882,9 +1969,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cfg_eval"
@@ -1894,7 +1981,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1971,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1981,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1993,14 +2080,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2039,7 +2126,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2275,18 +2362,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2303,20 +2390,20 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossfire"
-version = "3.1.18"
+version = "3.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df981decccf9b846c396ae513b3d2c6a1770d9593c8e47853d8fdb336c7bcb46"
+checksum = "111ce8f7abfbac38b4bc4f32a3a2dda1a8034b873c90c7899f302cc9dbbc05ec"
 dependencies = [
  "crossbeam-utils",
- "embed-collections",
  "futures-core",
  "parking_lot",
+ "pointers",
  "smallvec",
  "tokio",
 ]
@@ -2447,14 +2534,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "cynic"
-version = "3.13.2"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e722e1560ed4e4260cf35ac5fafc422aa7682c919db5a14209e4afad4446c2"
+checksum = "6260314e64d59ff1a962d465573ac6775fbf4624aa67613e220eb61f4a3d9a5c"
 dependencies = [
  "cynic-proc-macros",
  "ref-cast",
@@ -2467,9 +2554,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-codegen"
-version = "3.13.2"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde92ad70b36e9794eab14cbe915ae33e0ee8013844b7dcacad686830e107a5f"
+checksum = "04e68e191fc65c3b8a5b467368ef8e3d5f610ef770df664d5cca51de573c3010"
 dependencies = [
  "cynic-parser",
  "darling 0.20.11",
@@ -2478,15 +2565,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.118",
+ "syn 2.0.119",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "cynic-parser"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dfae2e0e25c72720197bde791ef9b840562ed6418eab6d8505f1d8fed27e86"
+checksum = "7793e157a59a0bd2142a5723860aeaef3aa459feae1467b597351e5f58251904"
 dependencies = [
  "indexmap 2.14.0",
  "lalrpop-util",
@@ -2495,14 +2582,14 @@ dependencies = [
 
 [[package]]
 name = "cynic-proc-macros"
-version = "3.13.2"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64118c37832e4ff3e2b8ffaf2f3a08d1b646fa049e90ff54826abac01005ae11"
+checksum = "8ca74b7363c9c675b6539aaf151c695cac83d3e7abc80dfbfbfdbfef27e4ec20"
 dependencies = [
  "cynic-codegen",
  "darling 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2536,7 +2623,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2550,7 +2637,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim 0.11.1",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2561,7 +2648,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2572,7 +2659,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2612,7 +2699,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2643,7 +2761,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -2688,7 +2806,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2709,7 +2827,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2719,7 +2837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2741,7 +2859,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -2780,13 +2898,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2906,14 +3024,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -2961,12 +3079,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embed-collections"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49c327886cdc0e7eda24cd0827f195db19a5f941425914bc6db76c79c64bc21"
-
-[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,43 +3117,44 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.2"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3073,11 +3186,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -3088,7 +3200,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -3098,7 +3210,7 @@ version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96df8cfa11d3c8e4e1a48b81c9c600ecbe8c11d1326f41e1524cc4d42f7bf6d9"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures",
  "http",
@@ -3107,6 +3219,18 @@ dependencies = [
  "pin-project",
  "rand 0.10.2",
  "tokio",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
 ]
 
 [[package]]
@@ -3121,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fastrlp"
@@ -3196,13 +3320,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+ "rapidhash",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3230,7 +3364,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs 0.6.3",
+ "zlib-rs 0.6.6",
 ]
 
 [[package]]
@@ -3303,9 +3437,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3328,9 +3462,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3351,15 +3485,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3368,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -3387,13 +3521,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3409,15 +3543,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-time"
@@ -3442,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3508,9 +3642,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3571,7 +3707,7 @@ dependencies = [
  "parking_lot",
  "signal-hook 0.3.18",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3584,7 +3720,7 @@ dependencies = [
  "gix-date",
  "gix-utils",
  "itoa",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "winnow 0.7.15",
 ]
 
@@ -3601,7 +3737,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-bom",
 ]
 
@@ -3611,7 +3747,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d982fc7ef0608e669851d0d2a6141dae74c60d5a27e8daa451f2a4857bbf41e2"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3620,7 +3756,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c356b3825677cb6ff579551bb8311a81821e184453cbd105e2fc5311b288eeb"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3646,7 +3782,7 @@ dependencies = [
  "gix-chunk",
  "gix-hash",
  "memmap2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3664,7 +3800,7 @@ dependencies = [
  "gix-sec",
  "memchr",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-bom",
  "winnow 0.7.15",
 ]
@@ -3675,11 +3811,11 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2409cffa4fe8b303847d5b6ba8df9da9ba65d302fc5ee474ea0cac5afde79840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3692,7 +3828,7 @@ dependencies = [
  "itoa",
  "jiff",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3716,7 +3852,7 @@ dependencies = [
  "gix-traverse",
  "gix-worktree",
  "imara-diff",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3736,7 +3872,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "gix-worktree",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3752,7 +3888,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3768,7 +3904,7 @@ dependencies = [
  "libc",
  "once_cell",
  "prodash",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "zlib-rs 0.5.5",
 ]
@@ -3791,7 +3927,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3805,7 +3941,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "gix-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3814,7 +3950,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8546300aee4c65c5862c22a3e321124a69b654a61a8b60de546a9284812b7e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bstr",
  "gix-features",
  "gix-path",
@@ -3829,7 +3965,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3862,7 +3998,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea6d3e9e11647ba49f441dea0782494cc6d2875ff43fa4ad9094e6957f42051"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bstr",
  "filetime",
  "fnv",
@@ -3881,7 +4017,7 @@ dependencies = [
  "memmap2",
  "rustix",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3892,7 +4028,7 @@ checksum = "115268ae5e3b3b7bc7fc77260eecee05acca458e45318ca45d35467fa81a3ac5"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3912,7 +4048,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "winnow 0.7.15",
 ]
 
@@ -3934,7 +4070,7 @@ dependencies = [
  "gix-quote",
  "parking_lot",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3952,7 +4088,7 @@ dependencies = [
  "gix-path",
  "memmap2",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3964,7 +4100,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3976,7 +4112,7 @@ dependencies = [
  "bstr",
  "gix-trace",
  "gix-validate",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3985,13 +4121,13 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed9e0c881933c37a7ef45288d6c5779c4a7b3ad240b4c37657e1d9829eb90085"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4009,7 +4145,7 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "maybe-async",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "winnow 0.7.15",
 ]
 
@@ -4021,7 +4157,7 @@ checksum = "96fc2ff2ec8cc0c92807f02eab1f00eb02619fc2810d13dc42679492fcc36757"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4041,7 +4177,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "winnow 0.7.15",
 ]
 
@@ -4057,7 +4193,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4066,7 +4202,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91898c83b18c635696f7355d171cfa74a52f38022ff89581f567768935ebc4c8"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -4075,7 +4211,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "gix-trace",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4090,7 +4226,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4099,7 +4235,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -4114,7 +4250,7 @@ dependencies = [
  "bstr",
  "gix-hash",
  "gix-lock",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4137,7 +4273,7 @@ dependencies = [
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4152,7 +4288,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4172,9 +4308,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
 
 [[package]]
 name = "gix-transport"
@@ -4189,7 +4325,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4198,7 +4334,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d052b83d1d1744be95ac6448ac02f95f370a8f6720e466be9ce57146e39f5280"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -4206,7 +4342,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4219,17 +4355,18 @@ dependencies = [
  "gix-features",
  "gix-path",
  "percent-encoding",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "gix-utils"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
+checksum = "b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8"
 dependencies = [
  "bstr",
  "fastrand",
+ "getrandom 0.4.3",
  "unicode-normalization",
 ]
 
@@ -4240,7 +4377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
 dependencies = [
  "bstr",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4264,9 +4401,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
@@ -4429,14 +4566,14 @@ dependencies = [
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.4"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "byteorder",
  "flate2",
- "nom",
+ "nom 8.0.0",
  "num-traits",
 ]
 
@@ -4484,6 +4621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4506,7 +4652,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -4529,10 +4675,10 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.4",
+ "rand 0.9.5",
  "ring",
  "socket2 0.5.10",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -4553,7 +4699,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "url",
@@ -4572,10 +4718,10 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.5",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4601,7 +4747,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4653,9 +4799,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c76f9c17f903a3a0487c7eb0766914baf94380cd7a9112043310e4bc4dc9547"
+checksum = "2f8c7f28951b250cc61b68d8d06aa2d73fb05f96d19380325fc235924768f579"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4667,8 +4813,8 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "serde",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -4685,7 +4831,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4693,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4707,7 +4853,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities",
  "moka",
  "parking_lot",
  "petgraph",
@@ -4716,7 +4862,7 @@ dependencies = [
  "serde_json",
  "smart-default",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "validator",
 ]
@@ -4724,25 +4870,25 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "bimap",
  "const-hex",
  "flagset",
  "hopr-types",
- "hopr-utils",
+ "hopr-utilities",
  "serde",
  "serde_bytes",
- "strum 0.28.0",
+ "strum",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4750,7 +4896,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utils",
+ "hopr-utilities",
  "smart-default",
  "tracing",
  "validator",
@@ -4758,13 +4904,14 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.5"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "4.0.2-rc.8"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "anyhow",
  "async-broadcast",
  "async-trait",
  "backon",
+ "bytesize",
  "cfg_eval",
  "const_format",
  "futures",
@@ -4778,7 +4925,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utils",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "parking_lot",
@@ -4787,8 +4934,8 @@ dependencies = [
  "serde",
  "serde_with",
  "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4798,40 +4945,40 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
  "petgraph",
  "rand 0.10.2",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
  "serde",
  "serde_bytes",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4843,7 +4990,7 @@ dependencies = [
  "hopr-api",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utils",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4852,8 +4999,8 @@ dependencies = [
  "serde",
  "serde_with",
  "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
  "tracing",
  "validator",
 ]
@@ -4861,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -4875,7 +5022,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "hopr-crypto-packet",
  "hopr-types",
- "hopr-utils",
+ "hopr-utilities",
  "lazy_static",
  "parking_lot",
  "pin-project",
@@ -4883,8 +5030,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4892,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -4900,23 +5047,23 @@ dependencies = [
  "hopr-protocol-app",
  "serde",
  "serde_cbor_2",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "async-trait",
  "hopr-api",
  "hopr-transport-session",
- "hopr-utils",
+ "hopr-utilities",
  "serde",
  "serde_with",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-retry",
  "tracing",
@@ -4926,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4937,7 +5084,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-crypto-packet",
- "hopr-utils",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4946,15 +5093,15 @@ dependencies = [
  "serde",
  "serde_with",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "validator",
 ]
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.5.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.5.1"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4963,20 +5110,20 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities",
  "parking_lot",
  "postcard",
  "redb",
- "strum 0.28.0",
+ "strum",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport"
-version = "0.32.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.33.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4988,6 +5135,7 @@ dependencies = [
  "dashmap",
  "futures",
  "futures-time",
+ "futures-timer",
  "halfbrown",
  "hopr-api",
  "hopr-crypto-packet",
@@ -4997,7 +5145,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utils",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "libp2p",
@@ -5005,11 +5153,13 @@ dependencies = [
  "multiaddr",
  "pcap-file",
  "proc-macro-regex",
+ "rand 0.10.2",
+ "rand_distr",
  "rust-stream-ext-concurrent",
  "serde",
  "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
  "tokio-util",
  "tracing",
  "validator",
@@ -5018,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5028,14 +5178,14 @@ dependencies = [
  "parking_lot",
  "serde",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5043,21 +5193,21 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utils",
+ "hopr-utilities",
  "lazy_static",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
  "pin-project",
  "quinn-udp 0.6.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5068,22 +5218,22 @@ dependencies = [
  "hopr-api",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utils",
+ "hopr-utilities",
  "humantime-serde",
  "moka",
  "rand 0.10.2",
  "serde",
  "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
  "tracing",
  "validator",
 ]
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.23.2"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+version = "0.23.3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5096,7 +5246,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utils",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -5106,8 +5256,8 @@ dependencies = [
  "serde",
  "serde_repr",
  "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -5115,12 +5265,12 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "hopr-protocol-app",
  "serde",
  "smart-default",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "validator",
 ]
 
@@ -5130,7 +5280,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aabecd53d5211c4a81f046d27bad0f7ad64659afcb5b88e0e410ecaa8928bf3"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "anyhow",
  "aquamarine",
  "arrayvec",
@@ -5175,9 +5325,9 @@ dependencies = [
  "sha2 0.11.0",
  "sha3 0.12.0",
  "smart-default",
- "strum 0.28.0",
+ "strum",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "typenum",
  "uuid",
@@ -5185,9 +5335,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-utils"
-version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+name = "hopr-utilities"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f60cbe7d588c9ee1bb454db33e6de7e969638a096ac6bdf1406fd7a43e476aa"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -5207,9 +5358,9 @@ dependencies = [
  "rayon",
  "serde",
  "serde_bytes",
- "socket2 0.6.4",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "socket2 0.6.5",
+ "strum",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5218,11 +5369,11 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=847d1c65167021367fe5b8a164cb707ccf7317d3#847d1c65167021367fe5b8a164cb707ccf7317d3"
+source = "git+https://github.com/hoprnet/hoprnet?rev=f201af29d4143cc28333b2d40ea092b67c2c320e#f201af29d4143cc28333b2d40ea092b67c2c320e"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytesize",
  "dashmap",
  "futures",
@@ -5230,13 +5381,13 @@ dependencies = [
  "hopr-api",
  "hopr-lib",
  "hopr-transport",
- "hopr-utils",
+ "hopr-utilities",
  "human-bandwidth",
  "lazy_static",
  "parking_lot",
  "serde",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5278,7 +5429,7 @@ dependencies = [
  "serde_json",
  "signal-hook 0.4.4",
  "smart-default",
- "strum 0.28.0",
+ "strum",
  "tempfile",
  "test-log",
  "tikv-jemalloc-ctl",
@@ -5298,13 +5449,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bimap",
  "bytesize",
  "const_format",
  "futures",
  "hopr-lib",
- "hopr-utils",
+ "hopr-utilities",
  "hopr-utils-session",
  "human-bandwidth",
  "lazy_static",
@@ -5316,8 +5467,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
+ "strum",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tower-http",
@@ -5347,7 +5498,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "syn 2.0.118",
+ "syn 2.0.119",
  "utoipa",
  "uuid",
 ]
@@ -5381,9 +5532,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -5391,9 +5542,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -5401,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5445,9 +5596,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "humantime-serde"
@@ -5461,9 +5612,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "serde",
  "subtle",
@@ -5473,9 +5624,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5527,7 +5678,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -5538,7 +5689,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5727,7 +5878,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "tokio",
  "url",
  "xmltree",
@@ -5777,7 +5928,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5847,7 +5998,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -5904,10 +6055,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -5918,21 +6071,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.28"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -5955,7 +6118,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -5970,7 +6133,7 @@ dependencies = [
  "quote",
  "rustc_version 0.4.1",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5989,24 +6152,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6081,9 +6244,9 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kstring"
-version = "2.0.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+checksum = "b609e7ca5ea38f093c20a4a102335b247221c9643b7a6bc3510f196f99499a9e"
 dependencies = [
  "static_assertions",
 ]
@@ -6117,9 +6280,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -6166,7 +6329,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6198,9 +6361,9 @@ dependencies = [
  "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_core 0.6.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "web-time",
 ]
@@ -6233,9 +6396,9 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "quick-protobuf",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rw-stream-sink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -6274,7 +6437,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -6289,10 +6452,10 @@ dependencies = [
  "hkdf 0.12.4",
  "multihash",
  "prost",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "zeroize",
 ]
@@ -6309,7 +6472,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "socket2 0.5.10",
  "tokio",
@@ -6346,10 +6509,10 @@ dependencies = [
  "multiaddr",
  "multihash",
  "quick-protobuf",
- "rand 0.8.6",
+ "rand 0.8.7",
  "snow",
  "static_assertions",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -6357,9 +6520,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc448b2de9f4745784e3751fe8bc6c473d01b8317edd5ababcb0dec803d843f"
+checksum = "9dcc597d70bf7f6f30cbe07081802c836184e48416e89e9ce73a0ba2c56a319e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6368,11 +6531,12 @@ dependencies = [
  "libp2p-identity",
  "libp2p-tls",
  "quinn",
- "rand 0.8.6",
+ "quinn-proto",
+ "rand 0.8.7",
  "ring",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -6389,7 +6553,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "tracing",
 ]
@@ -6404,7 +6568,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand 0.8.6",
+ "rand 0.8.7",
  "tracing",
 ]
 
@@ -6423,7 +6587,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive",
  "multistream-select",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "tokio",
  "tracing",
@@ -6438,7 +6602,7 @@ checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6452,7 +6616,7 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio",
  "tracing",
 ]
@@ -6471,7 +6635,7 @@ dependencies = [
  "ring",
  "rustls",
  "rustls-webpki",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "x509-parser",
  "yasna",
 ]
@@ -6500,7 +6664,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.10",
@@ -6529,9 +6693,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -6554,7 +6718,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.8.11",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6589,7 +6753,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6600,7 +6764,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6626,14 +6790,14 @@ checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -6687,9 +6851,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -6719,7 +6883,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6733,7 +6897,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-util",
  "parking_lot",
  "portable-atomic",
@@ -6763,12 +6927,13 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
  "base-x",
  "base256emoji",
+ "base45",
  "data-encoding",
  "data-encoding-macro",
 ]
@@ -6817,7 +6982,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "libc",
  "log",
  "netlink-packet-core",
@@ -6825,16 +6990,17 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+checksum = "e6f7398dddf5f152d2a91a2921a134c6097056e292c0d4b9906007855e7cece6"
 dependencies = [
  "bytes",
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6856,7 +7022,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6868,7 +7034,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6891,6 +7057,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6901,9 +7076,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -6963,7 +7138,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7065,7 +7240,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -7096,7 +7271,7 @@ dependencies = [
  "prost",
  "reqwest",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tonic-types",
@@ -7119,7 +7294,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -7141,8 +7316,8 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
@@ -7168,7 +7343,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7196,7 +7371,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7270,7 +7445,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -7282,9 +7457,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -7315,6 +7490,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pid"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7340,7 +7533,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7380,6 +7573,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "pointers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcdc93847ad24990939cce6e1804361e903efcb5f99daa5abd87943a9d6d7ba"
 
 [[package]]
 name = "polling"
@@ -7430,9 +7629,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -7523,7 +7722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7596,6 +7795,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82366fd7d8b7a440d66d13418820c69df9b3908bcb1a0476d7f5ce5d12f5a04d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro-error2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7604,7 +7813,18 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b511283ea8a74b4b39447b128c5d00f03a356b7424554b13e298a5550100d9ac"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7622,9 +7842,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -7637,7 +7857,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -7693,8 +7913,8 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "syn 2.0.118",
- "thiserror 2.0.18",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
  "typify",
  "unicode-ident",
 ]
@@ -7714,7 +7934,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "serde_yaml",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7737,7 +7957,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7746,16 +7966,12 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.11",
- "rusty-fork",
- "tempfile",
  "unarray",
 ]
 
@@ -7779,7 +7995,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7790,12 +8006,6 @@ checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-protobuf"
@@ -7821,20 +8031,20 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
  "futures-io",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp 0.5.14",
+ "quinn-udp 0.5.15",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
- "thiserror 2.0.18",
+ "socket2 0.6.5",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -7842,21 +8052,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "fastbloom",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -7864,16 +8076,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7884,15 +8096,15 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -7917,9 +8129,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -7929,9 +8141,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -7995,6 +8207,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8005,9 +8236,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
  "rustversion",
 ]
@@ -8060,34 +8291,34 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8097,9 +8328,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8140,7 +8371,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -8269,7 +8500,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -8293,14 +8524,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -8310,8 +8542,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types 0.12.2",
  "proptest",
- "rand 0.8.6",
- "rand 0.9.4",
+ "rand 0.8.7",
+ "rand 0.9.5",
  "rlp 0.5.2",
  "ruint-macro",
  "serde_core",
@@ -8327,9 +8559,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -8338,24 +8570,25 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.118",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "walkdir",
 ]
 
@@ -8371,9 +8604,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-hex"
@@ -8405,7 +8638,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -8414,7 +8647,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -8423,9 +8656,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -8451,9 +8684,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -8500,21 +8733,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rw-stream-sink"
@@ -8589,9 +8810,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -8608,7 +8829,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8667,7 +8888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.6",
+ "rand 0.8.7",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -8679,7 +8900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.4",
+ "rand 0.9.5",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -8707,7 +8928,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -8754,9 +8975,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -8770,7 +8991,7 @@ checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -8803,22 +9024,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8829,14 +9050,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -8859,13 +9080,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8877,7 +9098,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8898,14 +9119,14 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -8921,7 +9142,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8959,9 +9180,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -9104,15 +9325,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version 0.4.1",
  "simdutf8",
@@ -9153,7 +9374,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9196,9 +9417,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -9206,9 +9427,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -9257,7 +9478,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83561175f0a962dea437885589480d216d8741debf853e0d36edd526344fd273"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "byteorder",
  "keccak",
  "subtle",
@@ -9278,32 +9499,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "strum_macros",
 ]
 
 [[package]]
@@ -9315,7 +9515,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9337,9 +9537,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9348,14 +9559,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
+checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9375,7 +9586,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9384,7 +9595,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -9461,7 +9672,7 @@ checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9470,7 +9681,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
- "syn 2.0.118",
+ "syn 2.0.119",
  "test-log-core",
 ]
 
@@ -9485,11 +9696,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -9500,25 +9711,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -9565,9 +9776,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -9587,9 +9798,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -9607,9 +9818,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -9622,16 +9833,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -9639,13 +9850,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9671,9 +9882,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -9683,14 +9894,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -9706,23 +9918,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -9733,7 +9945,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http",
@@ -9745,7 +9957,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -9804,7 +10016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -9854,7 +10066,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9962,8 +10174,8 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "syn 2.0.118",
- "thiserror 2.0.18",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
  "unicode-ident",
 ]
 
@@ -9980,7 +10192,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.118",
+ "syn 2.0.119",
  "typify-impl",
 ]
 
@@ -10154,7 +10366,7 @@ checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10176,7 +10388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "axum",
- "base64 0.22.1",
+ "base64",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -10196,9 +10408,9 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -10224,16 +10436,15 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
 dependencies = [
- "darling 0.20.11",
- "once_cell",
- "proc-macro-error2",
+ "darling 0.23.0",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10288,15 +10499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10332,9 +10534,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10345,9 +10547,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10355,9 +10557,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10365,22 +10567,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -10414,9 +10616,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10434,9 +10636,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10509,7 +10711,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10520,7 +10722,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10574,16 +10776,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -10601,31 +10794,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -10644,22 +10820,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10668,22 +10832,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10692,22 +10844,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10716,22 +10856,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -10744,9 +10872,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -10805,10 +10933,10 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -10838,7 +10966,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.8.6",
+ "rand 0.8.7",
  "static_assertions",
 ]
 
@@ -10853,7 +10981,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.9.4",
+ "rand 0.9.5",
  "static_assertions",
  "web-time",
 ]
@@ -10892,28 +11020,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10933,7 +11061,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -10954,7 +11082,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10987,7 +11115,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -11012,15 +11140,15 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.33.7"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
+source = "git+https://github.com/hoprnet/hoprnet?rev=65e5902aff75bcd3d154a047644b042c72a7a90a#65e5902aff75bcd3d154a047644b042c72a7a90a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.33.7"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
+source = "git+https://github.com/hoprnet/hoprnet?rev=a6b1f6ed8c87e175ba10243a64f0d7c81c02169b#a6b1f6ed8c87e175ba10243a64f0d7c81c02169b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-packet"
 version = "1.4.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "bimap",
  "const-hex",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.3.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "hopr-lib"
 version = "4.0.2-rc.8"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "hopr-crypto-packet",
  "hopr-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-hopr"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-session"
 version = "1.2.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "aquamarine",
  "asynchronous-codec",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "hopr-protocol-start"
 version = "1.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "aquamarine",
  "flagset",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "hopr-session-server-forwarder"
 version = "0.1.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "async-trait",
  "hopr-api",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "hopr-strategy"
 version = "0.20.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport"
 version = "0.33.7"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-mixer"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.4"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-probe"
 version = "0.8.0"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-session"
 version = "0.23.3"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-tag-allocator"
 version = "0.1.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "hopr-protocol-app",
  "serde",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "hopr-utils-session"
 version = "1.2.1"
-source = "git+https://github.com/hoprnet/hoprnet?rev=c4ace897aa897200eac67a56d62c245cea8c05ad#c4ace897aa897200eac67a56d62c245cea8c05ad"
+source = "git+https://github.com/hoprnet/hoprnet?rev=2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd#2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
 hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a606efb226da9b12a61e2a9789b6377aa9477296" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a606efb226da9b12a61e2a9789b6377aa9477296", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a606efb226da9b12a61e2a9789b6377aa9477296", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a606efb226da9b12a61e2a9789b6377aa9477296", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "a606efb226da9b12a61e2a9789b6377aa9477296", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "a606efb226da9b12a61e2a9789b6377aa9477296", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "a606efb226da9b12a61e2a9789b6377aa9477296", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a606efb226da9b12a61e2a9789b6377aa9477296", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a606efb226da9b12a61e2a9789b6377aa9477296", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ hoprd = { path = "hoprd", default-features = false }
 hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
-hopr-utils = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "847d1c65167021367fe5b8a164cb707ccf7317d3", default-features = false }
+hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
 hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
 hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "1373c840e3c38844b17428c147ec1dbf190e90b1", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
 hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "f201af29d4143cc28333b2d40ea092b67c2c320e", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "72ff16432b37a0d2adab03f18449ef0f0ccfbe99", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
 hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
 hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "2a7c51c2089eb5f51f0cd5a79bca6d8daeb983cd", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
 hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a0706fdf98a483e9870c18b3f836e66ffd41ef4c", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
 hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a6b1f6ed8c87e175ba10243a64f0d7c81c02169b", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "65e5902aff75bcd3d154a047644b042c72a7a90a", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ hoprd-api = { path = "rest-api", default-features = false }
 hoprd-api-client = { path = "rest-api-client" }
 
 hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
-hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810" }
-hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
-hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
-hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
-hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
-hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
-hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
-hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
-hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "a3e186102ad5312abe0eff115b429348929eb810", default-features = false }
+hopr-chain-connector = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad" }
+hopr-ct-full-network = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
+hopr-lib = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
+hopr-network-graph = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
+hopr-session-server-forwarder = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
+hopr-strategy = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
+hopr-ticket-manager = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
+hopr-transport-p2p = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
+hopr-utils-session = { git = "https://github.com/hoprnet/hoprnet", rev = "c4ace897aa897200eac67a56d62c245cea8c05ad", default-features = false }
 
 # crates.io HOPR deps
 hopr-api = { version = "=1.10.0" }

--- a/hoprd/src/config.rs
+++ b/hoprd/src/config.rs
@@ -310,6 +310,7 @@ impl From<UserHoprLibConfig> for HoprLibConfig {
                 path_planner: Default::default(),
                 counter_flush_interval: HoprProtocolConfig::default().counter_flush_interval,
                 mixer: value.network.mixer,
+                transit_latency: None,
                 stream: Default::default(),
             },
             ..Default::default()

--- a/localcluster/Cargo.toml
+++ b/localcluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-localcluster"
-version = "0.2.2"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/localcluster/src/blokli_helper.rs
+++ b/localcluster/src/blokli_helper.rs
@@ -155,17 +155,36 @@ fn detect_container_ip(runtime: &str, name: &str) -> Option<String> {
 }
 
 fn try_get_container_ip(runtime: &str, name: &str) -> Option<String> {
-    // `container ls` output: NAME IMAGE OS ARCH STATE ADDR ...
-    // The container name appears in col[0], the ADDR (with CIDR prefix) in col[5].
     let out = Command::new(runtime).arg("ls").output().ok()?;
-
     let text = String::from_utf8_lossy(&out.stdout);
+
+    let basename = std::path::Path::new(runtime)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(runtime);
+
     for line in text.lines() {
         let cols: Vec<&str> = line.split_whitespace().collect();
-        if cols.first().copied() == Some(name) && cols.len() >= 6 {
-            let addr = cols[5];
+
+        let (matches, ip_col) = if basename == "container" {
+            // Apple `container ls` format: UUID IMAGE OS ARCH STATE IP CPUS MEMORY ...
+            // Apple does not show the container name in any column. Instead identify
+            // our container by: arch=="amd64" (we pass --arch amd64) + state=="running".
+            let matches = cols.len() >= 6
+                && cols.get(3).copied() == Some("amd64")
+                && cols.get(4).copied() == Some("running");
+            (matches, 5)
+        } else {
+            // Docker/Podman: NAME IMAGE COMMAND CREATED STATUS PORTS NAMES
+            // The container name appears in col[0].
+            let matches = cols.len() >= 6 && cols.first().copied() == Some(name);
+            (matches, 5)
+        };
+
+        if matches {
+            let addr = cols[ip_col];
             // Strip CIDR prefix (e.g. "192.168.64.2/24" → "192.168.64.2")
-            let ip = addr.split('/').next()?;
+            let ip = addr.split('/').next().unwrap_or("");
             if !ip.is_empty() && ip != "127.0.0.1" && ip != "::1" {
                 return Some(ip.to_string());
             }


### PR DESCRIPTION
## Summary

Bump hoprnet dependency rev to \`a606efb226\` which contains three session transport fixes for SURB starvation and reassembler timeouts:

1. **`hopr-transport/src/lib.rs`**: Allow \`HOPR_SESSION_FRAME_SIZE\` env var to set \`frame_mtu\` down to SESSION_MTU (1018) — previously clamped to 1028
2. **`hopr-protocol-session/socket/mod.rs`**: \`SessionSocket\` constructors now allow \`frame_size=SESSION_MTU\` (was clamped to \`C=1028\`, forcing 2-segment frames)
3. **`hopr-protocol-session/processing/segmenter.rs`**: \`Segmenter::new\` now allows \`frame_size=SESSION_MTU\` (was clamped to \`C=1028\` as a third hidden floor)

Depends on: https://github.com/hoprnet/hoprnet/pull/8287

https://claude.ai/code/session_01DgqM8mBtWmUyw8ohgnXT9T